### PR TITLE
fix: Azure DevOps team filter and teams loading on popup open

### DIFF
--- a/frontend/src/app/features/backlog/backlog.component.ts
+++ b/frontend/src/app/features/backlog/backlog.component.ts
@@ -1438,6 +1438,11 @@ ${jsonFormatRequirement}`;
       next: (projects) => {
         this.azureDevOpsProjects.set(projects);
         this.azureDevOpsProjectsLoading.set(false);
+        // If a project is already selected (e.g. from repo or previous open), load its teams
+        const project = this.azureDevOpsProject();
+        if (project) {
+          this.loadAzureDevOpsTeams(project);
+        }
       },
       error: (err) => {
         console.error('Failed to load Azure DevOps projects:', err);


### PR DESCRIPTION
- Use Team Field Values API for area path filtering (fixes team filter not working)
- Load teams when popup opens with project pre-selected (repo or previous open)