### PR TITLE
feat: sandbox auth, multi-platform setup, and backlog generation fixes

### DIFF
--- a/backend/src/API/Controllers/SandboxController.cs
+++ b/backend/src/API/Controllers/SandboxController.cs
@@ -1,0 +1,210 @@
+namespace DevPilot.API.Controllers;
+
+using System.Security.Claims;
+using System.Text.Json.Serialization;
+using DevPilot.Application.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+/// <summary>
+/// Authenticated proxy for sandbox container management.
+/// All calls require a valid JWT; the backend forwards them to the VPS manager
+/// using the internal API key, which is never exposed to the browser.
+/// </summary>
+[ApiController]
+[Route("api/sandboxes")]
+[Authorize]
+public class SandboxController : ControllerBase
+{
+    private readonly ISandboxService _sandboxService;
+    private readonly ILogger<SandboxController> _logger;
+
+    public SandboxController(ISandboxService sandboxService, ILogger<SandboxController> logger)
+    {
+        _sandboxService = sandboxService;
+        _logger = logger;
+    }
+
+    /// <summary>Returns all active sandboxes owned by the authenticated user.</summary>
+    [HttpGet]
+    public async Task<IActionResult> ListSandboxes(CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        if (userId == Guid.Empty)
+            return Unauthorized();
+
+        var sandboxes = await _sandboxService.ListSandboxesAsync(userId, cancellationToken);
+        return Ok(new { sandboxes = sandboxes.Select(s => new
+        {
+            id = s.Id,
+            port = s.Port,
+            bridge_port = s.BridgePort,
+            url = s.Url,
+            bridge_url = s.BridgeUrl,
+            status = s.Status,
+        })});
+    }
+
+    /// <summary>Creates a new sandbox container for the authenticated user.</summary>
+    [HttpPost]
+    public async Task<IActionResult> CreateSandbox(
+        [FromBody] CreateSandboxRequest request,
+        CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        if (userId == Guid.Empty)
+            return Unauthorized();
+
+        try
+        {
+            var result = await _sandboxService.CreateSandboxAsync(
+                userId,
+                new SandboxCreateRequest
+                {
+                    Resolution = request.Resolution,
+                    RepoUrl = request.RepoUrl,
+                    RepoName = request.RepoName,
+                    RepoBranch = request.RepoBranch,
+                    RepoArchiveUrl = request.RepoArchiveUrl,
+                    GithubToken = request.GithubToken,
+                    AzureDevOpsPat = request.AzureDevOpsPat,
+                    AiConfig = request.AiConfig is null ? null : new SandboxAiConfig
+                    {
+                        Provider = request.AiConfig.Provider,
+                        ApiKey = request.AiConfig.ApiKey,
+                        Model = request.AiConfig.Model,
+                        BaseUrl = request.AiConfig.BaseUrl,
+                    },
+                    ZedSettings = request.ZedSettings,
+                },
+                cancellationToken);
+
+            return Ok(new SandboxResponse
+            {
+                Id = result.Id,
+                Port = result.Port,
+                BridgePort = result.BridgePort,
+                Url = result.Url,
+                BridgeUrl = result.BridgeUrl,
+                Status = result.Status,
+                SandboxToken = result.SandboxToken,
+                VncPassword = result.VncPassword,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create sandbox for user {UserId}", userId);
+            return StatusCode(500, new { error = "Failed to create sandbox" });
+        }
+    }
+
+    /// <summary>Returns the status of a sandbox owned by the authenticated user.</summary>
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetSandbox(string id, CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        if (userId == Guid.Empty)
+            return Unauthorized();
+
+        var result = await _sandboxService.GetSandboxAsync(userId, id, cancellationToken);
+        if (result is null)
+            return NotFound();
+
+        return Ok(result);
+    }
+
+    /// <summary>Stops and removes a sandbox owned by the authenticated user.</summary>
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteSandbox(string id, CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        if (userId == Guid.Empty)
+            return Unauthorized();
+
+        var deleted = await _sandboxService.DeleteSandboxAsync(userId, id, cancellationToken);
+        if (!deleted)
+            return NotFound(new { error = "Sandbox not found or not owned by this user" });
+
+        return Ok(new { status = "deleted" });
+    }
+
+    private Guid GetUserId()
+    {
+        var raw = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return Guid.TryParse(raw, out var id) ? id : Guid.Empty;
+    }
+}
+
+// ── Request / Response DTOs ──────────────────────────────────────────────────
+
+public class CreateSandboxRequest
+{
+    [JsonPropertyName("resolution")]
+    public string? Resolution { get; set; }
+
+    [JsonPropertyName("repo_url")]
+    public string? RepoUrl { get; set; }
+
+    [JsonPropertyName("repo_name")]
+    public string? RepoName { get; set; }
+
+    [JsonPropertyName("repo_branch")]
+    public string? RepoBranch { get; set; }
+
+    [JsonPropertyName("repo_archive_url")]
+    public string? RepoArchiveUrl { get; set; }
+
+    [JsonPropertyName("github_token")]
+    public string? GithubToken { get; set; }
+
+    [JsonPropertyName("azure_devops_pat")]
+    public string? AzureDevOpsPat { get; set; }
+
+    [JsonPropertyName("ai_config")]
+    public AiConfigRequest? AiConfig { get; set; }
+
+    [JsonPropertyName("zed_settings")]
+    public object? ZedSettings { get; set; }
+}
+
+public class AiConfigRequest
+{
+    [JsonPropertyName("provider")]
+    public string Provider { get; set; } = "openai";
+
+    [JsonPropertyName("api_key")]
+    public string? ApiKey { get; set; }
+
+    [JsonPropertyName("model")]
+    public string Model { get; set; } = "gpt-4o";
+
+    [JsonPropertyName("base_url")]
+    public string? BaseUrl { get; set; }
+}
+
+public class SandboxResponse
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("port")]
+    public int Port { get; set; }
+
+    [JsonPropertyName("bridge_port")]
+    public int BridgePort { get; set; }
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = string.Empty;
+
+    [JsonPropertyName("bridge_url")]
+    public string BridgeUrl { get; set; } = string.Empty;
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("sandbox_token")]
+    public string SandboxToken { get; set; } = string.Empty;
+
+    [JsonPropertyName("vnc_password")]
+    public string VncPassword { get; set; } = string.Empty;
+}

--- a/backend/src/Application/Services/ISandboxService.cs
+++ b/backend/src/Application/Services/ISandboxService.cs
@@ -1,0 +1,85 @@
+namespace DevPilot.Application.Services;
+
+/// <summary>
+    /// Manages sandbox container lifecycle via the VPS manager API.
+    /// All calls are authenticated with the static manager API key; callers only
+    /// need to supply the authenticated user ID for ownership tracking.
+    /// </summary>
+    public interface ISandboxService
+    {
+        /// <summary>Creates a new sandbox container and returns its connection details.</summary>
+        Task<SandboxCreateResult> CreateSandboxAsync(
+            Guid userId,
+            SandboxCreateRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>Returns all sandboxes owned by the given user.</summary>
+        Task<IReadOnlyList<SandboxListItem>> ListSandboxesAsync(
+            Guid userId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>Returns the current status of a sandbox owned by the given user.</summary>
+        Task<SandboxStatusResult?> GetSandboxAsync(
+            Guid userId,
+            string sandboxId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>Stops and removes a sandbox owned by the given user.</summary>
+        Task<bool> DeleteSandboxAsync(
+            Guid userId,
+            string sandboxId,
+            CancellationToken cancellationToken = default);
+    }
+
+public record SandboxCreateRequest
+{
+    public string? Resolution { get; init; }
+    public string? RepoUrl { get; init; }
+    public string? RepoName { get; init; }
+    public string? RepoBranch { get; init; }
+    public string? RepoArchiveUrl { get; init; }
+    public string? GithubToken { get; init; }
+    public string? AzureDevOpsPat { get; init; }
+    public SandboxAiConfig? AiConfig { get; init; }
+    public object? ZedSettings { get; init; }
+}
+
+public record SandboxAiConfig
+{
+    public string Provider { get; init; } = "openai";
+    public string? ApiKey { get; init; }
+    public string Model { get; init; } = "gpt-4o";
+    public string? BaseUrl { get; init; }
+}
+
+public record SandboxCreateResult
+{
+    public string Id { get; init; } = string.Empty;
+    public int Port { get; init; }
+    public int BridgePort { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public string BridgeUrl { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+    public string SandboxToken { get; init; } = string.Empty;
+    public string VncPassword { get; init; } = string.Empty;
+}
+
+public record SandboxListItem
+{
+    public string Id { get; init; } = string.Empty;
+    public int Port { get; init; }
+    public int BridgePort { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public string BridgeUrl { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+}
+
+public record SandboxStatusResult
+{
+    public string Id { get; init; } = string.Empty;
+    public int Port { get; init; }
+    public int BridgePort { get; init; }
+    public string Url { get; init; } = string.Empty;
+    public string BridgeUrl { get; init; } = string.Empty;
+    public string Status { get; init; } = string.Empty;
+}

--- a/backend/src/Infrastructure/Sandbox/SandboxService.cs
+++ b/backend/src/Infrastructure/Sandbox/SandboxService.cs
@@ -1,0 +1,207 @@
+namespace DevPilot.Infrastructure.Sandbox;
+
+using System.Collections.Concurrent;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DevPilot.Application.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Calls the VPS sandbox manager API using a static API key that is never
+/// exposed to the browser.  Tracks sandbox ownership in memory so each user
+/// can only read/delete their own sandboxes.
+/// </summary>
+public class SandboxService : ISandboxService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<SandboxService> _logger;
+    private readonly string _publicIp;
+
+    // sandboxId → ownerUserId  (in-memory; cleared on process restart — acceptable since
+    // the manager's own state is also in-memory and lost on restart)
+    private static readonly ConcurrentDictionary<string, Guid> _ownershipMap = new();
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    public SandboxService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<SandboxService> logger)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _httpClient = httpClientFactory.CreateClient("VPSManager");
+
+        var gatewayUrl = _configuration["VPS:GatewayUrl"]
+            ?? throw new InvalidOperationException("VPS:GatewayUrl is not configured");
+        _httpClient.BaseAddress = new Uri(gatewayUrl);
+
+        var apiKey = _configuration["VPS:ManagerApiKey"] ?? string.Empty;
+        if (!string.IsNullOrEmpty(apiKey))
+            _httpClient.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+        _publicIp = _configuration["VPS:PublicIp"] ?? "localhost";
+    }
+
+    public async Task<SandboxCreateResult> CreateSandboxAsync(
+        Guid userId,
+        SandboxCreateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Creating sandbox for user {UserId}", userId);
+
+        var payload = BuildManagerPayload(request);
+
+        using var response = await _httpClient.PostAsJsonAsync("/sandboxes", payload, _jsonOptions, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var raw = await response.Content.ReadFromJsonAsync<ManagerCreateResponse>(_jsonOptions, cancellationToken)
+                  ?? throw new InvalidOperationException("Empty response from sandbox manager");
+
+        _ownershipMap[raw.Id] = userId;
+
+        return new SandboxCreateResult
+        {
+            Id = raw.Id,
+            Port = raw.Port,
+            BridgePort = raw.BridgePort,
+            Url = $"http://{_publicIp}:{raw.Port}/vnc.html",
+            BridgeUrl = $"http://{_publicIp}:{raw.BridgePort}",
+            Status = raw.Status,
+            SandboxToken = raw.SandboxToken,
+            VncPassword = raw.VncPassword,
+        };
+    }
+
+    public async Task<IReadOnlyList<SandboxListItem>> ListSandboxesAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.GetAsync("/sandboxes", cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var raw = await response.Content.ReadFromJsonAsync<ManagerListResponse>(_jsonOptions, cancellationToken);
+        if (raw?.Sandboxes is null) return [];
+
+        return raw.Sandboxes
+            .Where(s => _ownershipMap.TryGetValue(s.Id, out var owner) && owner == userId)
+            .Select(s => new SandboxListItem
+            {
+                Id = s.Id,
+                Port = s.Port,
+                BridgePort = s.BridgePort,
+                Url = $"http://{_publicIp}:{s.Port}/vnc.html",
+                BridgeUrl = $"http://{_publicIp}:{s.BridgePort}",
+                Status = s.Status,
+            })
+            .ToList();
+    }
+
+    public async Task<SandboxStatusResult?> GetSandboxAsync(
+        Guid userId,
+        string sandboxId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!IsOwner(userId, sandboxId))
+        {
+            _logger.LogWarning("User {UserId} attempted to access sandbox {SandboxId} they do not own", userId, sandboxId);
+            return null;
+        }
+
+        using var response = await _httpClient.GetAsync($"/sandboxes/{sandboxId}", cancellationToken);
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+            return null;
+        response.EnsureSuccessStatusCode();
+
+        var raw = await response.Content.ReadFromJsonAsync<ManagerStatusResponse>(_jsonOptions, cancellationToken);
+        if (raw is null) return null;
+
+        return new SandboxStatusResult
+        {
+            Id = raw.Id,
+            Port = raw.Port,
+            BridgePort = raw.BridgePort,
+            Url = $"http://{_publicIp}:{raw.Port}/vnc.html",
+            BridgeUrl = $"http://{_publicIp}:{raw.BridgePort}",
+            Status = raw.Status,
+        };
+    }
+
+    public async Task<bool> DeleteSandboxAsync(
+        Guid userId,
+        string sandboxId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!IsOwner(userId, sandboxId))
+        {
+            _logger.LogWarning("User {UserId} attempted to delete sandbox {SandboxId} they do not own", userId, sandboxId);
+            return false;
+        }
+
+        using var response = await _httpClient.DeleteAsync($"/sandboxes/{sandboxId}", cancellationToken);
+        if (response.IsSuccessStatusCode)
+        {
+            _ownershipMap.TryRemove(sandboxId, out _);
+            return true;
+        }
+        return false;
+    }
+
+    private bool IsOwner(Guid userId, string sandboxId) =>
+        _ownershipMap.TryGetValue(sandboxId, out var owner) && owner == userId;
+
+    private static object BuildManagerPayload(SandboxCreateRequest req)
+    {
+        return new
+        {
+            resolution = req.Resolution,
+            repo_url = req.RepoUrl,
+            repo_name = req.RepoName,
+            repo_branch = req.RepoBranch,
+            repo_archive_url = req.RepoArchiveUrl,
+            github_token = req.GithubToken,
+            azure_devops_pat = req.AzureDevOpsPat,
+            ai_config = req.AiConfig is null ? null : new
+            {
+                provider = req.AiConfig.Provider,
+                api_key = req.AiConfig.ApiKey,
+                model = req.AiConfig.Model,
+                base_url = req.AiConfig.BaseUrl,
+            },
+            zed_settings = req.ZedSettings,
+        };
+    }
+
+    // DTO types for deserialising manager responses
+    private record ManagerListResponse(
+        [property: JsonPropertyName("sandboxes")] List<ManagerListItem> Sandboxes);
+
+    private record ManagerListItem(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("port")] int Port,
+        [property: JsonPropertyName("bridge_port")] int BridgePort,
+        [property: JsonPropertyName("status")] string Status);
+
+    private record ManagerCreateResponse(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("port")] int Port,
+        [property: JsonPropertyName("bridge_port")] int BridgePort,
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("bridge_url")] string BridgeUrl,
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("sandbox_token")] string SandboxToken,
+        [property: JsonPropertyName("vnc_password")] string VncPassword);
+
+    private record ManagerStatusResponse(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("port")] int Port,
+        [property: JsonPropertyName("bridge_port")] int BridgePort,
+        [property: JsonPropertyName("status")] string Status);
+}

--- a/backend/src/Infrastructure/Services/InfrastructureServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/Services/InfrastructureServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using DevPilot.Infrastructure.Persistence;
 using DevPilot.Infrastructure.Zed;
 using DevPilot.Infrastructure.ACP;
 using DevPilot.Infrastructure.VPS;
+using DevPilot.Infrastructure.Sandbox;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -91,6 +92,10 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<IZedSessionService, ZedSessionService>();
         services.AddScoped<IACPClient, ACPClient>();
         services.AddScoped<IVPSAnalysisService, VPSAnalysisService>();
+
+        // Register sandbox manager proxy (authenticated via API key)
+        services.AddHttpClient("VPSManager");
+        services.AddScoped<ISandboxService, SandboxService>();
 
         return services;
     }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -117,7 +117,7 @@ export class AppComponent implements OnInit, OnDestroy {
             return;
           }
           const config = {
-            url: getVncHtmlUrl(sandbox.port),
+            url: stored.vncUrl || getVncHtmlUrl(sandbox.port),
             autoConnect: true,
             scalingMode: 'local' as const,
             useIframe: true
@@ -129,7 +129,10 @@ export class AppComponent implements OnInit, OnDestroy {
             sandbox.id,
             title,
             bridgePort,
-            stored.implementationContext ?? undefined
+            stored.implementationContext ?? undefined,
+            stored.sandboxToken,
+            stored.bridgeUrl,
+            stored.vncPassword
           );
         });
       },

--- a/frontend/src/app/components/backlog-generator-modal/backlog-generator-modal.component.ts
+++ b/frontend/src/app/components/backlog-generator-modal/backlog-generator-modal.component.ts
@@ -579,14 +579,18 @@ export class BacklogGeneratorModalComponent implements OnInit, OnDestroy {
           // Open VNC viewer
           this.vncViewerService.open(
             {
-              url: getVncHtmlUrl(sandbox.port),
+              url: sandbox.url ? `${sandbox.url}?autoconnect=true&resize=scale` : getVncHtmlUrl(sandbox.port),
               autoConnect: true,
               scalingMode: 'local',
               useIframe: true
             },
             sandbox.id,
             `${repo.name}`,
-            sandbox.bridge_port!
+            sandbox.bridge_port!,
+            undefined,
+            sandbox.sandbox_token,
+            sandbox.bridge_url,
+            sandbox.vnc_password
           );
 
           // Wait for Zed to fully initialize before sending prompt

--- a/frontend/src/app/components/vnc-viewer/vnc-viewer.component.html
+++ b/frontend/src/app/components/vnc-viewer/vnc-viewer.component.html
@@ -5,9 +5,9 @@
 
 <!-- Minimized Widget (not shown when embedded) -->
 @if (dockPosition() === 'minimized' && !embedded()) {
-  <div class="vnc-minimized" [class.ready-for-pr]="readyForPr()" (click)="toggleMinimize()" [style.right]="minimizedStyle().right">
-    <!-- Ready for PR Alert Badge -->
-    @if (readyForPr()) {
+  <div class="vnc-minimized" [class.ready-for-pr]="readyForPr() && !isBacklogSandbox() && !isAnalysisSandbox()" (click)="toggleMinimize()" [style.right]="minimizedStyle().right">
+    <!-- Ready for PR Alert Badge (only for story implementation sandboxes) -->
+    @if (readyForPr() && !isBacklogSandbox() && !isAnalysisSandbox()) {
       <div class="pr-alert-badge" (click)="toggleMinimize(); $event.stopPropagation()">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
           <circle cx="18" cy="18" r="3"/>
@@ -47,7 +47,7 @@
       }
     </div>
     <div class="minimized-info">
-      @if (readyForPr()) {
+      @if (readyForPr() && !isBacklogSandbox() && !isAnalysisSandbox()) {
         <span class="minimized-pr-ready">Ready for PR!</span>
         <span class="minimized-story">{{ implementationContext()?.storyTitle || viewerTitle() }}</span>
       } @else {
@@ -253,8 +253,8 @@
       <!-- AI Conversations Panel (Right Side) -->
       @if (bridgePort()) {
         <div class="conversations-panel" [class.collapsed]="!showConversations()">
-          <!-- Push & Create PR Button (when implementing user story) -->
-          @if (implementationContext()) {
+          <!-- Push & Create PR Button (only for story implementation, not backlog/analysis sandboxes) -->
+          @if (implementationContext() && !isBacklogSandbox() && !isAnalysisSandbox()) {
             <div class="push-pr-section">
               @if (pushPrSuccess()) {
                 <div class="push-pr-success">

--- a/frontend/src/app/components/vnc-viewer/vnc-viewer.component.ts
+++ b/frontend/src/app/components/vnc-viewer/vnc-viewer.component.ts
@@ -532,7 +532,8 @@ export class VncViewerComponent implements OnInit, OnDestroy {
       clearTimeout(this.connectionTimeout);
     }
 
-    const finalUrl = this.vncService.buildIframeUrl(config);
+    const vncPassword = this.vncViewerService.getViewer(this.viewerId())?.vncPassword;
+    const finalUrl = this.vncService.buildIframeUrl(config, vncPassword);
     console.log('VNC iframe URL:', finalUrl);
 
     // Set connection state and URL

--- a/frontend/src/app/core/auth/oidc-config.loader.ts
+++ b/frontend/src/app/core/auth/oidc-config.loader.ts
@@ -47,17 +47,8 @@ export function loadOidcConfigs(http: HttpClient): Observable<OpenIdConfiguratio
         useRefreshToken: false,
         ignoreNonceAfterRefresh: true,
         triggerAuthorizationResultEvent: true,
-        // Disable automatic userinfo endpoint call — the backend fetches
-        // user profile via the configured ProfileEndpoint (e.g. Microsoft Graph /v1.0/me)
-        // using the access token. With autoUserInfo true the library calls the IdP userinfo
-        // endpoint and can fail (e.g. "Received no user data"), which then fails the whole login.
         autoUserInfo: false,
-        // Skip client-side ID token validation; we validate the ID token on the backend.
-        // Avoids Azure AD quirks (issuer/audience format, nonce, etc.) that can cause
-        // "token(s) validation failed" in the library while the tokens are still valid.
         disableIdTokenValidation: true,
-        // Debug so the library logs the exact validation failure (e.g. incorrect aud, incorrect nonce)
-        // when disableIdTokenValidation is set to false for troubleshooting.
         logLevel: LogLevel.Debug,
       }));
     }),

--- a/frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -9,8 +9,8 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
   const token = authService.getToken();
 
-  if (token) {
-    // Clone request and add Authorization header
+  // Don't override Authorization header if it's already set (e.g. sandbox bridge token)
+  if (token && !req.headers.has('Authorization')) {
     const clonedRequest = req.clone({
       setHeaders: {
         Authorization: `Bearer ${token}`

--- a/frontend/src/app/core/services/sandbox-bridge.service.ts
+++ b/frontend/src/app/core/services/sandbox-bridge.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, catchError, of, map, interval, Subject, takeUntil, switchMap, filter, take, tap } from 'rxjs';
 import { VPS_CONFIG } from '../config/vps.config';
+import { VncViewerService } from './vnc-viewer.service';
 
 export interface ChatResponse {
   response: string;
@@ -53,19 +54,39 @@ export interface ZedConversationsResponse {
 })
 export class SandboxBridgeService {
   private http = inject(HttpClient);
+  private vncViewerService = inject(VncViewerService);
 
   /**
-   * Get the bridge API URL for a sandbox
+   * Get the bridge API URL for a sandbox.
+   * Prefer the bridgeUrl stored on the matching VNC viewer (set at sandbox creation),
+   * falling back to building the URL from VPS_CONFIG for backwards compatibility.
    */
   private getBridgeUrl(bridgePort: number): string {
+    const viewer = this.vncViewerService.getViewerByBridgePort(bridgePort);
+    if (viewer?.bridgeUrl) {
+      return viewer.bridgeUrl;
+    }
     return `http://${VPS_CONFIG.ip}:${bridgePort}`;
+  }
+
+  /**
+   * Build Authorization headers for a specific bridge port.
+   * Looks up the sandbox token from the matching VNC viewer.
+   * Returns an empty HttpHeaders object when no token is available.
+   */
+  private getAuthHeaders(bridgePort: number): HttpHeaders {
+    const viewer = this.vncViewerService.getViewerByBridgePort(bridgePort);
+    const token = viewer?.sandboxToken;
+    return token
+      ? new HttpHeaders({ Authorization: `Bearer ${token}` })
+      : new HttpHeaders();
   }
 
   /**
    * Check if the bridge API is healthy
    */
   health(bridgePort: number): Observable<HealthResponse> {
-    return this.http.get<HealthResponse>(`${this.getBridgeUrl(bridgePort)}/health`).pipe(
+    return this.http.get<HealthResponse>(`${this.getBridgeUrl(bridgePort)}/health`, { headers: this.getAuthHeaders(bridgePort) }).pipe(
       catchError(error => {
         console.error('Bridge health check failed:', error);
         return of({ status: 'error', api_configured: false, model: '', project_path: '' });
@@ -78,7 +99,7 @@ export class SandboxBridgeService {
    * Use this as fallback when xdotool-based prompting isn't working
    */
   chat(bridgePort: number, message: string): Observable<ChatResponse & { conversation_id?: string }> {
-    return this.http.post<ChatResponse & { conversation_id?: string }>(`${this.getBridgeUrl(bridgePort)}/chat`, { message });
+    return this.http.post<ChatResponse & { conversation_id?: string }>(`${this.getBridgeUrl(bridgePort)}/chat`, { message }, { headers: this.getAuthHeaders(bridgePort) });
   }
 
   /**
@@ -92,7 +113,7 @@ export class SandboxBridgeService {
     zed_window_id: string | null;
     conversations_count: number;
   }> {
-    return this.http.get<any>(`${this.getBridgeUrl(bridgePort)}/debug`).pipe(
+    return this.http.get<any>(`${this.getBridgeUrl(bridgePort)}/debug`, { headers: this.getAuthHeaders(bridgePort) }).pipe(
       catchError(error => {
         console.error('Debug info failed:', error);
         return of({ status: 'error', api_configured: false, model: '', zed_running: false, zed_window_id: null, conversations_count: 0 });
@@ -104,7 +125,7 @@ export class SandboxBridgeService {
    * Analyze the project
    */
   analyze(bridgePort: number, focus?: string): Observable<AnalysisResponse> {
-    return this.http.post<AnalysisResponse>(`${this.getBridgeUrl(bridgePort)}/analyze`, { focus });
+    return this.http.post<AnalysisResponse>(`${this.getBridgeUrl(bridgePort)}/analyze`, { focus }, { headers: this.getAuthHeaders(bridgePort) });
   }
 
   /**
@@ -113,7 +134,8 @@ export class SandboxBridgeService {
   openZedAgent(bridgePort: number): Observable<{ status: string; window_id?: string }> {
     return this.http.post<{ status: string; window_id?: string }>(
       `${this.getBridgeUrl(bridgePort)}/zed/open-agent`,
-      {}
+      {},
+      { headers: this.getAuthHeaders(bridgePort) }
     );
   }
 
@@ -123,7 +145,8 @@ export class SandboxBridgeService {
   sendZedPrompt(bridgePort: number, prompt: string): Observable<{ status: string; prompt_sent?: string }> {
     return this.http.post<{ status: string; prompt_sent?: string }>(
       `${this.getBridgeUrl(bridgePort)}/zed/send-prompt`,
-      { prompt }
+      { prompt },
+      { headers: this.getAuthHeaders(bridgePort) }
     );
   }
 
@@ -151,7 +174,7 @@ export class SandboxBridgeService {
 
         console.log(`[WaitForZed] Checking Zed status... (${Math.round(elapsed/1000)}s elapsed)`);
         
-        this.http.get<any>(`${this.getBridgeUrl(bridgePort)}/health`).subscribe({
+        this.http.get<any>(`${this.getBridgeUrl(bridgePort)}/health`, { headers: this.getAuthHeaders(bridgePort) }).subscribe({
           next: (health) => {
             console.log('[WaitForZed] Health response:', health);
             
@@ -189,7 +212,7 @@ export class SandboxBridgeService {
    * Get conversation history
    */
   getHistory(bridgePort: number): Observable<ConversationMessage[]> {
-    return this.http.get<{ history: ConversationMessage[] }>(`${this.getBridgeUrl(bridgePort)}/history`).pipe(
+    return this.http.get<{ history: ConversationMessage[] }>(`${this.getBridgeUrl(bridgePort)}/history`, { headers: this.getAuthHeaders(bridgePort) }).pipe(
       map(res => res.history)
     );
   }
@@ -198,14 +221,14 @@ export class SandboxBridgeService {
    * Clear conversation history
    */
   clearHistory(bridgePort: number): Observable<{ status: string }> {
-    return this.http.delete<{ status: string }>(`${this.getBridgeUrl(bridgePort)}/history`);
+    return this.http.delete<{ status: string }>(`${this.getBridgeUrl(bridgePort)}/history`, { headers: this.getAuthHeaders(bridgePort) });
   }
 
   /**
    * List project files
    */
   listFiles(bridgePort: number): Observable<{ files: ProjectFile[]; path: string }> {
-    return this.http.get<{ files: ProjectFile[]; path: string }>(`${this.getBridgeUrl(bridgePort)}/project/files`);
+    return this.http.get<{ files: ProjectFile[]; path: string }>(`${this.getBridgeUrl(bridgePort)}/project/files`, { headers: this.getAuthHeaders(bridgePort) });
   }
 
   /**
@@ -214,7 +237,8 @@ export class SandboxBridgeService {
   readFile(bridgePort: number, filepath: string): Observable<{ content: string; path: string }> {
     return this.http.post<{ content: string; path: string }>(
       `${this.getBridgeUrl(bridgePort)}/project/read`,
-      { path: filepath }
+      { path: filepath },
+      { headers: this.getAuthHeaders(bridgePort) }
     );
   }
 
@@ -249,7 +273,8 @@ export class SandboxBridgeService {
         pr_title: params.prTitle,
         pr_body: params.prBody ?? '',
         git_credentials: params.gitCredentials
-      }
+      },
+      { headers: this.getAuthHeaders(bridgePort) }
     );
   }
 
@@ -262,7 +287,7 @@ export class SandboxBridgeService {
    * Use this to get AI responses from Zed's agent panel
    */
   getZedConversations(bridgePort: number): Observable<ZedConversationsResponse> {
-    return this.http.get<ZedConversationsResponse>(`${this.getBridgeUrl(bridgePort)}/zed/conversations`).pipe(
+    return this.http.get<ZedConversationsResponse>(`${this.getBridgeUrl(bridgePort)}/zed/conversations`, { headers: this.getAuthHeaders(bridgePort) }).pipe(
       catchError(error => {
         console.error('Failed to get Zed conversations:', error);
         return of({ conversations: [], count: 0 });
@@ -274,7 +299,7 @@ export class SandboxBridgeService {
    * Get the latest Zed conversation
    */
   getLatestZedConversation(bridgePort: number): Observable<ZedConversation | null> {
-    return this.http.get<ZedConversation>(`${this.getBridgeUrl(bridgePort)}/zed/latest`).pipe(
+    return this.http.get<ZedConversation>(`${this.getBridgeUrl(bridgePort)}/zed/latest`, { headers: this.getAuthHeaders(bridgePort) }).pipe(
       catchError(error => {
         console.error('Failed to get latest conversation:', error);
         return of(null);
@@ -306,7 +331,7 @@ export class SandboxBridgeService {
    * These are from when user selects "DevPilot" in Zed's agent panel
    */
   getAcpConversations(bridgePort: number): Observable<ZedConversationsResponse> {
-    return this.http.get<ZedConversationsResponse>(`${this.getBridgeUrl(bridgePort)}/acp/conversations`).pipe(
+    return this.http.get<ZedConversationsResponse>(`${this.getBridgeUrl(bridgePort)}/acp/conversations`, { headers: this.getAuthHeaders(bridgePort) }).pipe(
       catchError(error => {
         console.error('Failed to get ACP conversations:', error);
         return of({ conversations: [], count: 0 });
@@ -318,7 +343,7 @@ export class SandboxBridgeService {
    * Get the latest ACP conversation
    */
   getLatestAcpConversation(bridgePort: number): Observable<ZedConversation | null> {
-    return this.http.get<ZedConversation>(`${this.getBridgeUrl(bridgePort)}/acp/latest`).pipe(
+    return this.http.get<ZedConversation>(`${this.getBridgeUrl(bridgePort)}/acp/latest`, { headers: this.getAuthHeaders(bridgePort) }).pipe(
       catchError(error => {
         console.error('Failed to get latest ACP conversation:', error);
         return of(null);
@@ -331,7 +356,7 @@ export class SandboxBridgeService {
    * This is the recommended method for getting all AI responses
    */
   getAllConversations(bridgePort: number): Observable<ZedConversationsResponse> {
-    return this.http.get<ZedConversationsResponse>(`${this.getBridgeUrl(bridgePort)}/all-conversations`).pipe(
+    return this.http.get<ZedConversationsResponse>(`${this.getBridgeUrl(bridgePort)}/all-conversations`, { headers: this.getAuthHeaders(bridgePort) }).pipe(
       catchError(error => {
         console.error('Failed to get all conversations:', error);
         return of({ conversations: [], count: 0 });

--- a/frontend/src/app/core/services/sandbox.service.ts
+++ b/frontend/src/app/core/services/sandbox.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
-import { getSandboxApiUrl, getVncHtmlUrl } from '../config/vps.config';
+import { environment } from '../../../environments/environment';
 
 export interface Sandbox {
   id: string;
@@ -12,6 +12,10 @@ export interface Sandbox {
   url?: string;
   bridge_url?: string;
   created_at?: number;
+  /** Per-sandbox bearer token for authenticating bridge API calls */
+  sandbox_token?: string;
+  /** Per-sandbox VNC password for noVNC iframe authentication */
+  vnc_password?: string;
 }
 
 export interface CreateSandboxResponse {
@@ -21,6 +25,10 @@ export interface CreateSandboxResponse {
   url: string;
   bridge_url?: string;
   status: string;
+  /** Per-sandbox bearer token for authenticating bridge API calls */
+  sandbox_token?: string;
+  /** Per-sandbox VNC password for noVNC iframe authentication */
+  vnc_password?: string;
 }
 
 export interface CreateSandboxRequest {
@@ -49,7 +57,7 @@ export interface CreateSandboxRequest {
   providedIn: 'root'
 })
 export class SandboxService {
-  private apiUrl = getSandboxApiUrl();
+  private apiUrl = `${environment.apiUrl}/sandboxes`;
   private currentSandboxSubject = new BehaviorSubject<Sandbox | null>(null);
   
   currentSandbox$ = this.currentSandboxSubject.asObservable();
@@ -71,17 +79,17 @@ export class SandboxService {
       ai_config: request.ai_config ? { ...request.ai_config, api_key: '***' } : undefined
     });
 
-    return this.http.post<CreateSandboxResponse>(`${this.apiUrl}/sandboxes`, request).pipe(
+    return this.http.post<CreateSandboxResponse>(this.apiUrl, request).pipe(
       tap(sandbox => {
-        // Update the URL with the actual VPS IP
-        sandbox.url = getVncHtmlUrl(sandbox.port);
         this.currentSandboxSubject.next({
           id: sandbox.id,
           port: sandbox.port,
           bridge_port: sandbox.bridge_port,
           status: sandbox.status,
           url: sandbox.url,
-          bridge_url: sandbox.bridge_url
+          bridge_url: sandbox.bridge_url,
+          sandbox_token: sandbox.sandbox_token,
+          vnc_password: sandbox.vnc_password,
         });
       }),
       catchError(error => {
@@ -95,7 +103,7 @@ export class SandboxService {
    * Get all active sandboxes
    */
   listSandboxes(): Observable<Sandbox[]> {
-    return this.http.get<{ sandboxes: Sandbox[] }>(`${this.apiUrl}/sandboxes`).pipe(
+    return this.http.get<{ sandboxes: Sandbox[] }>(this.apiUrl).pipe(
       map(response => response.sandboxes),
       catchError(error => {
         console.error('Failed to list sandboxes:', error);
@@ -108,7 +116,7 @@ export class SandboxService {
    * Get a specific sandbox's status
    */
   getSandbox(sandboxId: string): Observable<Sandbox | null> {
-    return this.http.get<Sandbox>(`${this.apiUrl}/sandboxes/${sandboxId}`).pipe(
+    return this.http.get<Sandbox>(`${this.apiUrl}/${sandboxId}`).pipe(
       catchError(error => {
         console.error('Failed to get sandbox:', error);
         return of(null);
@@ -120,7 +128,7 @@ export class SandboxService {
    * Stop and remove a sandbox
    */
   deleteSandbox(sandboxId: string): Observable<boolean> {
-    return this.http.delete<{ status: string }>(`${this.apiUrl}/sandboxes/${sandboxId}`).pipe(
+    return this.http.delete<{ status: string }>(`${this.apiUrl}/${sandboxId}`).pipe(
       tap(() => {
         if (this.currentSandboxSubject.value?.id === sandboxId) {
           this.currentSandboxSubject.next(null);
@@ -138,7 +146,7 @@ export class SandboxService {
    * Stop a sandbox (but keep container for later restart)
    */
   stopSandbox(sandboxId: string): Observable<boolean> {
-    return this.http.post<{ status: string }>(`${this.apiUrl}/sandboxes/${sandboxId}/stop`, {}).pipe(
+    return this.http.post<{ status: string }>(`${this.apiUrl}/${sandboxId}/stop`, {}).pipe(
       map(() => true),
       catchError(error => {
         console.error('Failed to stop sandbox:', error);
@@ -151,8 +159,8 @@ export class SandboxService {
    * Check if sandbox API is available
    */
   checkHealth(): Observable<boolean> {
-    return this.http.get<{ status: string }>(`${this.apiUrl}/health`).pipe(
-      map(response => response.status === 'ok'),
+    return this.http.get<{ status: string }>(this.apiUrl).pipe(
+      map(() => true),
       catchError(() => of(false))
     );
   }

--- a/frontend/src/app/core/services/vnc-viewer.service.ts
+++ b/frontend/src/app/core/services/vnc-viewer.service.ts
@@ -22,6 +22,12 @@ export interface VncViewer {
   title?: string;
   createdAt: number; // Timestamp for tracking oldest
   bridgePort?: number; // Port for Bridge API communication
+  /** Full bridge URL (e.g. http://localhost:7102) returned by the backend at sandbox creation */
+  bridgeUrl?: string;
+  /** Per-sandbox bearer token for authenticating bridge API calls */
+  sandboxToken?: string;
+  /** Per-sandbox VNC password for noVNC iframe authentication */
+  vncPassword?: string;
   /** Set when opened from backlog for user story implementation - enables Push & Create PR */
   implementationContext?: ImplementationContext;
   /** True when implementation is complete and waiting for PR */
@@ -41,6 +47,14 @@ export interface StoredSandboxContext {
   implementationContext?: ImplementationContext;
   title?: string;
   bridgePort?: number;
+  /** Full bridge URL persisted so auth works after page refresh */
+  bridgeUrl?: string;
+  /** Bearer token persisted so auth works after page refresh */
+  sandboxToken?: string;
+  /** Full VNC iframe URL persisted so restore uses the correct host (not VPS_CONFIG fallback) */
+  vncUrl?: string;
+  /** Per-sandbox VNC password */
+  vncPassword?: string;
 }
 
 @Injectable({
@@ -92,15 +106,15 @@ export class VncViewerService {
    * @param bridgePort Optional Bridge API port for sandbox communication
    * @param implementationContext Optional context when opened for user story implementation (enables Push & Create PR)
    */
-  open(config: VncConfig, id?: string, title?: string, bridgePort?: number, implementationContext?: ImplementationContext): string {
+  open(config: VncConfig, id?: string, title?: string, bridgePort?: number, implementationContext?: ImplementationContext, sandboxToken?: string, bridgeUrl?: string, vncPassword?: string): string {
     const viewerId = id || `sandbox-${Date.now()}`;
-    const hasExistingViewers = this.viewersSubject.value.length > 0;
     
     console.log('VncViewerService.open called:', { 
       viewerId, 
       currentCount: this.count,
       maxSandboxes: this.MAX_SANDBOXES,
-      bridgePort
+      bridgePort,
+      hasSandboxToken: !!sandboxToken
     });
     
     // Check if viewer with same ID exists
@@ -111,16 +125,23 @@ export class VncViewerService {
       const merged = implementationContext ?? viewers[existingIndex].implementationContext;
       const mergedTitle = title ?? viewers[existingIndex].title;
       const mergedPort = bridgePort ?? viewers[existingIndex].bridgePort;
+      const mergedToken = sandboxToken ?? viewers[existingIndex].sandboxToken;
+      const mergedBridgeUrl = bridgeUrl ?? viewers[existingIndex].bridgeUrl;
+      const mergedVncPassword = vncPassword ?? viewers[existingIndex].vncPassword;
+      const mergedVncUrl = config.url || viewers[existingIndex].config.url;
       viewers[existingIndex] = {
         ...viewers[existingIndex],
         config,
         dockPosition: 'floating',
         bridgePort: mergedPort,
+        sandboxToken: mergedToken,
+        bridgeUrl: mergedBridgeUrl,
+        vncPassword: mergedVncPassword,
         implementationContext: merged,
         title: mergedTitle
       };
       if (merged || mergedTitle || mergedPort !== undefined) {
-        this.setStoredContext(viewerId, { implementationContext: merged, title: mergedTitle, bridgePort: mergedPort });
+        this.setStoredContext(viewerId, { implementationContext: merged, title: mergedTitle, bridgePort: mergedPort, sandboxToken: mergedToken, bridgeUrl: mergedBridgeUrl, vncUrl: mergedVncUrl, vncPassword: mergedVncPassword });
       }
       this.viewersSubject.next(viewers);
       return viewerId;
@@ -143,11 +164,14 @@ export class VncViewerService {
       title: title || `Sandbox ${viewerId.slice(0, 6)}`,
       createdAt: Date.now(),
       bridgePort,
+      sandboxToken,
+      bridgeUrl,
+      vncPassword,
       implementationContext
     };
 
     if (implementationContext || title || bridgePort !== undefined) {
-      this.setStoredContext(viewerId, { implementationContext, title, bridgePort });
+      this.setStoredContext(viewerId, { implementationContext, title, bridgePort, sandboxToken, bridgeUrl, vncUrl: config.url, vncPassword });
     }
     
     console.log('Creating new viewer:', newViewer.id, 'Total will be:', this.count + 1);
@@ -266,6 +290,13 @@ export class VncViewerService {
     return this.viewersSubject.value.reduce((oldest, current) => 
       current.createdAt < oldest.createdAt ? current : oldest
     );
+  }
+
+  /**
+   * Find a viewer by its bridge port (used by SandboxBridgeService to look up auth token)
+   */
+  getViewerByBridgePort(bridgePort: number): VncViewer | undefined {
+    return this.viewersSubject.value.find(v => v.bridgePort === bridgePort);
   }
 
   /**

--- a/frontend/src/app/core/services/vnc.service.ts
+++ b/frontend/src/app/core/services/vnc.service.ts
@@ -112,20 +112,22 @@ export class VncService {
   }
 
   /**
-   * Build iframe URL from VNC config
-   * Simple format: just use the URL as-is if it's already correct,
-   * or ensure it points to vnc.html with autoconnect
+   * Build iframe URL from VNC config.
+   * When a per-sandbox VNC password is provided it is appended as the
+   * `password` query parameter understood by noVNC.
    */
-  buildIframeUrl(config: VncConfig): string {
+  buildIframeUrl(config: VncConfig, vncPassword?: string): string {
     let url = config.url.trim();
     
     console.log('buildIframeUrl input:', url);
     
-    // If URL already contains vnc.html, just ensure autoconnect is set
+    // If URL already contains vnc.html, ensure autoconnect is set then append password
     if (url.includes('vnc.html')) {
-      // Add autoconnect if not present
       if (!url.includes('autoconnect')) {
         url += (url.includes('?') ? '&' : '?') + 'autoconnect=true';
+      }
+      if (vncPassword) {
+        url += `&password=${encodeURIComponent(vncPassword)}`;
       }
       console.log('buildIframeUrl output:', url);
       return url;
@@ -158,8 +160,11 @@ export class VncService {
       port = parts[1] || '6080';
     }
     
-    // Build simple URL - noVNC will connect to websocket on same host:port automatically
-    const finalUrl = `http://${host}:${port}/vnc.html?autoconnect=true&resize=scale`;
+    // Build URL — noVNC connects to websocket on same host:port automatically
+    let finalUrl = `http://${host}:${port}/vnc.html?autoconnect=true&resize=scale`;
+    if (vncPassword) {
+      finalUrl += `&password=${encodeURIComponent(vncPassword)}`;
+    }
     console.log('buildIframeUrl output:', finalUrl);
     
     return finalUrl;

--- a/frontend/src/app/features/backlog/backlog.component.ts
+++ b/frontend/src/app/features/backlog/backlog.component.ts
@@ -1055,7 +1055,7 @@ export class BacklogComponent implements OnInit, OnDestroy {
           // Open VNC viewer with implementation context for Push & Create PR
           this.vncViewerService.open(
             {
-              url: getVncHtmlUrl(sandbox.port),
+              url: sandbox.url ? `${sandbox.url}?autoconnect=true&resize=scale` : getVncHtmlUrl(sandbox.port),
               autoConnect: true,
               scalingMode: 'local',
               useIframe: true
@@ -1070,7 +1070,10 @@ export class BacklogComponent implements OnInit, OnDestroy {
               storyTitle: story.title,
               storyId: story.id,
               azureDevOpsWorkItemId: story.azureDevOpsWorkItemId
-            }
+            },
+            sandbox.sandbox_token,
+            sandbox.bridge_url,
+            sandbox.vnc_password
           );
           
           // Only send implementation prompt for new stories (no existing PR)
@@ -1240,7 +1243,11 @@ Start by exploring the codebase and then provide your implementation plan.`;
         return;
       }
       const viewers = this.vncViewerService.getViewers();
-      const activeSandbox = viewers.find(v => v.title?.includes(repo.name)) || null;
+      // Match only the backlog sandbox for this exact repository (not implementation sandboxes for stories)
+      const activeSandbox = viewers.find(v =>
+        v.implementationContext?.repositoryId === repo.id &&
+        v.implementationContext?.storyId?.startsWith('backlog-')
+      ) || null;
       if (activeSandbox?.bridgePort) {
         this.sendBacklogPrompt(activeSandbox.bridgePort);
       } else {
@@ -1311,7 +1318,7 @@ Start by exploring the codebase and then provide your implementation plan.`;
         setTimeout(() => {
           this.vncViewerService.open(
             {
-              url: getVncHtmlUrl(sandbox.port),
+              url: sandbox.url ? `${sandbox.url}?autoconnect=true&resize=scale` : getVncHtmlUrl(sandbox.port),
               autoConnect: true,
               scalingMode: 'local',
               useIframe: true
@@ -1325,7 +1332,10 @@ Start by exploring the codebase and then provide your implementation plan.`;
               defaultBranch: repo.defaultBranch || 'main',
               storyTitle: 'Backlog Generation',
               storyId: `backlog-${repo.id}`
-            }
+            },
+            sandbox.sandbox_token,
+            sandbox.bridge_url,
+            sandbox.vnc_password
           );
 
           this.generationState.set('waiting_sandbox');
@@ -1473,7 +1483,7 @@ ${jsonFormatRequirement}`;
   }
 
   private containsBacklogJson(response: string): boolean {
-    return response.includes('"epics"') && (response.includes('```json') || response.includes('"features"'));
+    return response.includes('"epics"');
   }
 
   private parseAndSaveBacklog(response: string): void {
@@ -1502,12 +1512,23 @@ ${jsonFormatRequirement}`;
     try {
       // Extract JSON from markdown code block if present
       let jsonStr = response;
-      const jsonMatch = response.match(/```json\s*([\s\S]*?)\s*```/);
+      const jsonMatch = response.match(/```(?:json)?\s*([\s\S]*?)```/);
       if (jsonMatch) {
-        jsonStr = jsonMatch[1];
+        jsonStr = jsonMatch[1].trim();
+      } else {
+        // Fallback: extract raw JSON object
+        const jsonStart = response.indexOf('{');
+        const jsonEnd = response.lastIndexOf('}');
+        if (jsonStart !== -1 && jsonEnd !== -1) {
+          jsonStr = response.substring(jsonStart, jsonEnd + 1);
+        }
       }
 
       const backlog = JSON.parse(jsonStr);
+
+      if (!backlog.epics || !Array.isArray(backlog.epics)) {
+        throw new Error('Invalid backlog format: missing epics array');
+      }
 
       this.generationState.set('saving');
 

--- a/frontend/src/app/features/code/code.component.ts
+++ b/frontend/src/app/features/code/code.component.ts
@@ -5,10 +5,10 @@ import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 import { Subscription, interval, firstValueFrom } from 'rxjs';
 import { takeWhile, switchMap } from 'rxjs/operators';
-import { 
-  RepositoryService, 
-  RepositoryTree, 
-  RepositoryTreeItem, 
+import {
+  RepositoryService,
+  RepositoryTree,
+  RepositoryTreeItem,
   RepositoryFileContent,
   RepositoryBranch,
   PullRequest,
@@ -18,6 +18,7 @@ import {
 import { SandboxService, CreateSandboxResponse } from '../../core/services/sandbox.service';
 import { AIConfigService } from '../../core/services/ai-config.service';
 import { VncViewerService } from '../../core/services/vnc-viewer.service';
+import { SandboxBridgeService } from '../../core/services/sandbox-bridge.service';
 import { MarkdownPipe } from '../../shared/pipes/markdown.pipe';
 import { Repository } from '../../shared/models/repository.model';
 import { CodeHighlightPipe } from '../../shared/pipes/code-highlight.pipe';
@@ -57,7 +58,7 @@ export class CodeComponent implements OnInit, OnDestroy {
   fileLoading = signal<boolean>(false);
   error = signal<string | null>(null);
   showBranchDropdown = signal<boolean>(false);
-  
+
   // Tab and PR state
   activeTab = signal<TabType>('code');
   pullRequests = signal<PullRequest[]>([]);
@@ -142,8 +143,9 @@ export class CodeComponent implements OnInit, OnDestroy {
     private sandboxService: SandboxService,
     private aiConfigService: AIConfigService,
     private vncViewerService: VncViewerService,
+    private sandboxBridgeService: SandboxBridgeService,
     private http: HttpClient
-  ) {}
+  ) { }
 
   ngOnDestroy(): void {
     this.analysisSubscription?.unsubscribe();
@@ -157,7 +159,7 @@ export class CodeComponent implements OnInit, OnDestroy {
     if (repoId) {
       this.repositoryId.set(repoId);
       this.loadRepository(repoId);
-      
+
       // Check for existing analysis sandbox to reconnect after refresh
       this.checkForExistingAnalysisSandbox();
     } else {
@@ -211,36 +213,34 @@ export class CodeComponent implements OnInit, OnDestroy {
   private checkForExistingAnalysisSandbox(): void {
     const currentRepoId = this.repositoryId();
     const viewers = this.vncViewerService.getViewers();
-    
+
     // Only reconnect to analysis sandbox for the CURRENT repository
-    const analysisViewer = viewers.find(v => 
-      v.title?.includes('Analysis') && 
+    const analysisViewer = viewers.find(v =>
+      v.title?.includes('Analysis') &&
       v.implementationContext?.repositoryId === currentRepoId
     );
-    
+
     if (analysisViewer && analysisViewer.bridgePort) {
       console.log('Found existing analysis sandbox for this repo, reconnecting...', analysisViewer.id);
-      
+
       this.analysisSandboxId.set(analysisViewer.id);
       this.analysisLoading.set(true);
       this.analysisStatus.set('Reconnecting to analysis...');
-      
-      // Resume polling for the response
-      const bridgeUrl = `http://${VPS_CONFIG.ip}:${analysisViewer.bridgePort}`;
-      this.resumeAnalysisPolling(bridgeUrl, analysisViewer.id);
+
+      this.resumeAnalysisPolling(analysisViewer.bridgePort, analysisViewer.id);
     }
   }
 
   /**
    * Resume polling for analysis response after reconnecting to an existing sandbox
    */
-  private async resumeAnalysisPolling(bridgeUrl: string, sandboxId: string): Promise<void> {
+  private async resumeAnalysisPolling(bridgePort: number, sandboxId: string): Promise<void> {
     const branch = this.currentBranch() || 'main';
-    
+
     try {
       this.analysisStatus.set('Waiting for AI response...');
-      const response = await this.waitForZedResponse(bridgeUrl);
-      
+      const response = await this.waitForZedResponse(bridgePort);
+
       // Save the response
       this.analysisStatus.set('Saving results...');
       this.repositoryService.saveCodeAnalysis(this.repositoryId(), {
@@ -271,7 +271,7 @@ export class CodeComponent implements OnInit, OnDestroy {
 
   private async loadRepository(repositoryId: string): Promise<void> {
     let repo = this.repositoryService.getRepositoryById(repositoryId);
-    
+
     if (!repo) {
       this.repositoryService.getRepositories().subscribe({
         next: () => {
@@ -366,10 +366,10 @@ export class CodeComponent implements OnInit, OnDestroy {
     this.repositoryService.getRepositoryTree(repoId, node.path, branch || undefined).subscribe({
       next: (tree) => {
         const children = this.convertToTreeNodes(tree.items, node.depth + 1);
-        this.updateNode(node.path, { 
-          children, 
-          isExpanded: true, 
-          isLoading: false 
+        this.updateNode(node.path, {
+          children,
+          isExpanded: true,
+          isLoading: false
         });
       },
       error: (err) => {
@@ -409,7 +409,7 @@ export class CodeComponent implements OnInit, OnDestroy {
 
     this.fileLoading.set(true);
     this.selectedFilePath.set(path);
-    
+
     // Clear previous file analysis
     this.fileAnalysisResult.set(null);
     this.fileAnalysisError.set(null);
@@ -419,7 +419,7 @@ export class CodeComponent implements OnInit, OnDestroy {
       next: (content) => {
         this.selectedFile.set(content);
         this.fileLoading.set(false);
-        
+
         // Try to load stored analysis for this file
         this.loadFileAnalysis(path);
       },
@@ -463,7 +463,7 @@ export class CodeComponent implements OnInit, OnDestroy {
     if (item.type === 'dir') {
       return 'folder';
     }
-    
+
     const ext = item.name.split('.').pop()?.toLowerCase() || '';
     const iconMap: Record<string, string> = {
       'ts': 'typescript',
@@ -593,7 +593,7 @@ export class CodeComponent implements OnInit, OnDestroy {
     const repo = this.repository();
     const repoId = this.repositoryId();
     const branch = this.currentBranch();
-    
+
     if (!repo) {
       this.analysisError.set('Repository not loaded');
       return;
@@ -646,12 +646,12 @@ export class CodeComponent implements OnInit, OnDestroy {
       next: (sandbox) => {
         this.analysisSandboxId.set(sandbox.id);
         this.analysisStatus.set('Waiting for environment...');
-        
+
         // Open VNC viewer in minimized state after delay
         setTimeout(() => {
           this.vncViewerService.open(
             {
-              url: getVncHtmlUrl(sandbox.port),
+              url: sandbox.url ? `${sandbox.url}?autoconnect=true&resize=scale` : getVncHtmlUrl(sandbox.port),
               autoConnect: true,
               scalingMode: 'local',
               useIframe: true
@@ -666,9 +666,12 @@ export class CodeComponent implements OnInit, OnDestroy {
               defaultBranch: branch,
               storyTitle: 'Code Analysis',
               storyId: `analysis-${this.repositoryId()}`
-            }
+            },
+            sandbox.sandbox_token,
+            sandbox.bridge_url,
+            sandbox.vnc_password
           );
-          
+
           // Start analysis after viewer is opened
           this.waitForZedAndAnalyze(sandbox, repo.name, branch);
         }, VPS_CONFIG.sandboxReadyDelayMs);
@@ -690,25 +693,23 @@ export class CodeComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const bridgeUrl = `http://${VPS_CONFIG.ip}:${bridgePort}`;
-    
     try {
       // Wait for Zed to be ready (poll health endpoint)
       this.analysisStatus.set('Waiting for Zed IDE...');
-      await this.waitForZedReady(bridgeUrl);
+      await this.waitForZedReady(bridgePort);
 
       // Send analysis prompt
       this.analysisStatus.set('Analyzing repository...');
       const prompt = this.buildAnalysisPrompt(repoName);
-      await this.sendPromptToZed(bridgeUrl, prompt);
+      await this.sendPromptToZed(bridgePort, prompt);
 
       // Wait for response
       this.analysisStatus.set('Waiting for AI response...');
-      const response = await this.waitForZedResponse(bridgeUrl);
+      const response = await this.waitForZedResponse(bridgePort);
 
       // Parse and save response
       this.analysisStatus.set('Saving results...');
-      
+
       // Store the full response as summary for comprehensive display
       this.repositoryService.saveCodeAnalysis(this.repositoryId(), {
         branch,
@@ -737,14 +738,13 @@ export class CodeComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async waitForZedReady(bridgeUrl: string, maxAttempts = 60): Promise<void> {
+  private async waitForZedReady(bridgePort: number, maxAttempts = 60): Promise<void> {
     for (let i = 0; i < maxAttempts; i++) {
       try {
         const response = await firstValueFrom(
-          this.http.get<{ status: string }>(`${bridgeUrl}/health`)
+          this.sandboxBridgeService.health(bridgePort)
         );
         if (response.status === 'ok') {
-          // Wait a bit more for Zed to fully initialize
           await this.delay(3000);
           return;
         }
@@ -756,22 +756,22 @@ export class CodeComponent implements OnInit, OnDestroy {
     throw new Error('Zed IDE did not become ready in time');
   }
 
-  private async sendPromptToZed(bridgeUrl: string, prompt: string): Promise<void> {
+  private async sendPromptToZed(bridgePort: number, prompt: string): Promise<void> {
     await firstValueFrom(
-      this.http.post(`${bridgeUrl}/zed/send-prompt`, { prompt })
+      this.sandboxBridgeService.sendZedPrompt(bridgePort, prompt)
     );
   }
 
-  private async waitForZedResponse(bridgeUrl: string, maxAttempts = 600): Promise<string> {
+  private async waitForZedResponse(bridgePort: number, maxAttempts = 600): Promise<string> {
     // 600 attempts * 2 seconds = 20 minutes max wait time for comprehensive analysis
     let lastMessageLength = 0;
     let stableCount = 0;
     let initialConversationId: string | null = null;
-    
+
     // First, get the current conversation ID to detect new responses
     try {
       const initial = await firstValueFrom(
-        this.http.get<{ id: string; assistant_message: string } | null>(`${bridgeUrl}/zed/latest`)
+        this.sandboxBridgeService.getLatestZedConversation(bridgePort)
       );
       if (initial) {
         initialConversationId = initial.id;
@@ -779,27 +779,27 @@ export class CodeComponent implements OnInit, OnDestroy {
     } catch {
       // No existing conversation
     }
-    
+
     for (let i = 0; i < maxAttempts; i++) {
       try {
         const response = await firstValueFrom(
-          this.http.get<{ id: string; assistant_message: string; user_message: string } | null>(`${bridgeUrl}/zed/latest`)
+          this.sandboxBridgeService.getLatestZedConversation(bridgePort)
         );
-        
+
         if (response && response.assistant_message) {
           const content = response.assistant_message;
-          
+
           // Only consider responses from our prompt (new conversation or updated one)
           const isNewConversation = !initialConversationId || response.id !== initialConversationId;
           const hasContent = content.length > 100;
-          
+
           // Update status with progress
           if (hasContent) {
             const elapsedMinutes = Math.floor((i * 2) / 60);
             const charCount = Math.floor(content.length / 1000);
             this.analysisStatus.set(`Analyzing... ${charCount}k chars received (${elapsedMinutes}m elapsed)`);
           }
-          
+
           if (isNewConversation && hasContent) {
             // Check if response is complete (stable for a few polls)
             if (content.length === lastMessageLength) {
@@ -924,7 +924,7 @@ Be thorough and specific. Use the markdown formatting exactly as shown above for
   } {
     const sections: Record<string, string> = {};
     const sectionNames = ['Summary', 'Architecture', 'Key Components', 'Dependencies', 'Recommendations'];
-    
+
     for (const name of sectionNames) {
       const regex = new RegExp(`##\\s*${name}[\\s\\S]*?(?=##|$)`, 'i');
       const match = response.match(regex);
@@ -949,7 +949,7 @@ Be thorough and specific. Use the markdown formatting exactly as shown above for
     if (sandboxId) {
       // Close VNC viewer
       this.vncViewerService.close(sandboxId);
-      
+
       // Delete sandbox
       this.sandboxService.deleteSandbox(sandboxId).subscribe({
         next: () => console.log('Analysis sandbox cleaned up'),
@@ -965,7 +965,7 @@ Be thorough and specific. Use the markdown formatting exactly as shown above for
 
   refreshAnalysis(): void {
     const repoId = this.repositoryId();
-    
+
     // Delete existing analysis first, then trigger new one
     this.repositoryService.deleteAnalysis(repoId).subscribe({
       next: () => {
@@ -982,9 +982,9 @@ Be thorough and specific. Use the markdown formatting exactly as shown above for
 
   formatAnalysisDate(dateStr: string): string {
     const date = new Date(dateStr);
-    return date.toLocaleDateString('en-US', { 
-      year: 'numeric', 
-      month: 'short', 
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit'

--- a/frontend/src/app/features/repositories/repositories.component.ts
+++ b/frontend/src/app/features/repositories/repositories.component.ts
@@ -824,14 +824,18 @@ export class RepositoriesComponent implements OnInit, OnDestroy, AfterViewInit {
           // (sandbox.url from API contains placeholder 'HOST_IP')
           this.vncViewerService.open(
             {
-              url: getVncHtmlUrl(sandbox.port),
+              url: sandbox.url ? `${sandbox.url}?autoconnect=true&resize=scale` : getVncHtmlUrl(sandbox.port),
               autoConnect: true,
               scalingMode: 'local',
               useIframe: true
             },
             sandbox.id,
             `${repo.name}`,
-            sandbox.bridge_port
+            sandbox.bridge_port,
+            undefined,
+            sandbox.sandbox_token,
+            sandbox.bridge_url,
+            sandbox.vnc_password
           );
           
           // Trigger auto-analysis via Bridge API after Zed has time to start

--- a/infra/sandbox/README.md
+++ b/infra/sandbox/README.md
@@ -1,292 +1,294 @@
 # DevPilot Sandbox
 
 Multi-container sandbox system that creates isolated desktop environments on demand.
-Each "Analyze with AI" click spawns a fresh, isolated Docker container.
+Each sandbox is an independent Docker container with its own XFCE desktop, Zed IDE, and bridge API.
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                        VPS                               │
-│  ┌─────────────────────────────────────────────────────┐ │
-│  │           Sandbox Manager (port 8090)               │ │
-│  │                                                     │ │
-│  │   POST /sandboxes → Creates new container           │ │
-│  │   DELETE /sandboxes/{id} → Removes container        │ │
-│  └─────────────────────────────────────────────────────┘ │
-│                          │                               │
-│            ┌─────────────┼─────────────┐                │
-│            ▼             ▼             ▼                │
-│     ┌──────────┐  ┌──────────┐  ┌──────────┐           │
-│     │ Sandbox  │  │ Sandbox  │  │ Sandbox  │           │
-│     │  :6100   │  │  :6101   │  │  :6102   │  ...      │
-│     │ (user A) │  │ (user B) │  │ (user C) │           │
-│     └──────────┘  └──────────┘  └──────────┘           │
-│                                                         │
-└─────────────────────────────────────────────────────────┘
+Browser (Angular)
+       │
+       │  JWT  (user auth)
+       ▼
+┌──────────────────────┐
+│   .NET Backend API   │  ← validates JWT, stores ownership
+│   port 8080          │  ← uses X-Api-Key to talk to manager
+└──────────┬───────────┘
+           │  X-Api-Key
+           ▼
+┌──────────────────────┐        ┌──────────────────────────────────────────┐
+│   Sandbox Manager    │        │                  VPS                     │
+│   Flask  port 8090   │ ──────▶│  ┌──────────┐  ┌──────────┐  ┌────────┐ │
+│   (Python)           │        │  │ Sandbox  │  │ Sandbox  │  │  ...   │ │
+└──────────────────────┘        │  │  noVNC   │  │  noVNC   │  │        │ │
+                                │  │  :6100   │  │  :6101   │  │        │ │
+                                │  │  Bridge  │  │  Bridge  │  │        │ │
+                                │  │  :7100   │  │  :7101   │  │        │ │
+                                │  └──────────┘  └──────────┘  └────────┘ │
+                                └──────────────────────────────────────────┘
+
+Browser also talks directly to each sandbox's Bridge API with a per-sandbox Bearer token:
+  Authorization: Bearer <sandbox_token>  →  http://VPS_IP:7100/...
 ```
 
-## Quick Start
+### Security model
 
-### On your VPS:
+| Channel | Auth |
+|---------|------|
+| Browser → Backend API | JWT (user login) |
+| Backend → Sandbox Manager | `X-Api-Key` header (static key from `.env`) |
+| Browser → Sandbox Bridge API | `Authorization: Bearer <sandbox_token>` (per-sandbox, generated at creation) |
+| Browser → noVNC iframe | VNC password (per-sandbox, generated at creation) |
+
+---
+
+## Platform Setup
+
+Choose your platform — each has a dedicated folder with a setup script and README:
+
+| Platform | Folder | Command |
+|----------|--------|---------|
+| 🐧 Linux (VPS) | [`linux/`](linux/) | `sudo bash infra/sandbox/linux/setup.sh` |
+| 🍎 macOS (local dev) | [`mac/`](mac/) | `bash infra/sandbox/mac/setup.sh` |
+| 🪟 Windows (Docker Desktop) | [`windows/`](windows/) | `.\infra\sandbox\windows\setup.ps1` |
+
+### After setup — configure the backend
+
+In `backend/src/API/appsettings.json`:
+
+```json
+{
+  "VPS": {
+    "GatewayUrl": "http://YOUR_VPS_IP:8090",
+    "ManagerApiKey": "<key printed at end of setup>",
+    "PublicIp": "YOUR_VPS_IP_OR_localhost",
+    "Enabled": true
+  }
+}
+```
+
+> **Corporate proxy / Zscaler?** Place your `.crt` certificates in [`certs/`](certs/) before running any setup script. See [`certs/README.md`](certs/README.md).
+
+---
+
+## Manager API
+
+All requests require the `X-Api-Key` header. The key is stored in `/opt/devpilot-sandbox/.env`.
 
 ```bash
-# Download and run
-curl -sSL https://raw.githubusercontent.com/YOUR_REPO/sandbox/setup.sh | sudo bash
+export API_KEY=$(sudo grep MANAGER_API_KEY /opt/devpilot-sandbox/.env | cut -d= -f2)
+export BASE=http://YOUR_VPS_IP:8090
 ```
 
-### Configure Frontend:
+### Endpoints
 
-Update `frontend/src/app/core/config/vps.config.ts`:
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Health check (no auth required) |
+| `GET` | `/sandboxes` | List all active sandboxes |
+| `POST` | `/sandboxes` | Create a new sandbox |
+| `GET` | `/sandboxes/{id}` | Get sandbox status |
+| `DELETE` | `/sandboxes/{id}` | Stop and remove a sandbox |
 
-```typescript
-export const VPS_CONFIG = {
-  ip: 'YOUR_VPS_IP',
-  novncPort: 6080,
-  sandboxApiPort: 8090,
-  password: ''
-};
-```
-
-## API Endpoints
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/health` | Health check |
-| GET | `/sandboxes` | List all active sandboxes |
-| POST | `/sandboxes` | Create new sandbox |
-| GET | `/sandboxes/{id}` | Get sandbox status |
-| DELETE | `/sandboxes/{id}` | Delete sandbox |
-| POST | `/sandboxes/{id}/stop` | Stop sandbox |
-
-### Create Sandbox
+### Create sandbox
 
 ```bash
-curl -X POST http://YOUR_VPS_IP:8090/sandboxes
+curl -X POST $BASE/sandboxes \
+  -H "X-Api-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "repo_url": "https://github.com/org/repo.git",
+    "repo_name": "repo",
+    "repo_branch": "main",
+    "ai_config": {
+      "provider": "openai",
+      "api_key": "sk-...",
+      "model": "gpt-4o"
+    }
+  }'
 ```
 
 Response:
 ```json
 {
-  "id": "abc123",
+  "id": "a1b2c3d4",
   "port": 6100,
+  "bridge_port": 7100,
   "url": "http://YOUR_VPS_IP:6100/vnc.html",
-  "status": "starting"
+  "bridge_url": "http://YOUR_VPS_IP:7100",
+  "status": "starting",
+  "sandbox_token": "<random bearer token>",
+  "vnc_password": "<random vnc password>"
 }
 ```
 
-### List Sandboxes
+### List sandboxes
 
 ```bash
-curl http://YOUR_VPS_IP:8090/sandboxes
+curl $BASE/sandboxes -H "X-Api-Key: $API_KEY"
 ```
 
-### Delete Sandbox
+### Delete sandbox
 
 ```bash
-curl -X DELETE http://YOUR_VPS_IP:8090/sandboxes/abc123
+curl -X DELETE $BASE/sandboxes/a1b2c3d4 -H "X-Api-Key: $API_KEY"
 ```
 
-## Management
+---
+
+## Sandbox Bridge API
+
+Each sandbox exposes a bridge API on its bridge port (7100–7200).
+Requests must include the per-sandbox bearer token returned at creation time.
 
 ```bash
-cd /opt/devpilot-sandbox
-
-./run.sh start     # Start manager
-./run.sh stop      # Stop manager
-./run.sh status    # Show status
-./run.sh logs      # View logs
-./run.sh rebuild   # Rebuild desktop image
-./run.sh cleanup   # Remove all sandbox containers
+export BRIDGE=http://YOUR_VPS_IP:7100
+export TOKEN=<sandbox_token>
 ```
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/all-conversations` | List Zed AI conversations |
+| `GET` | `/latest-conversation` | Get the most recent conversation |
+| `POST` | `/zed/send-prompt` | Send a prompt to Zed AI |
+| `GET` | `/files` | List files in the project |
+| `GET` | `/file?path=...` | Read a file |
+
+```bash
+# Get latest AI conversation
+curl $BRIDGE/latest-conversation \
+  -H "Authorization: Bearer $TOKEN"
+
+# Send a prompt to Zed
+curl -X POST $BRIDGE/zed/send-prompt \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Explain the architecture of this project"}'
+```
+
+---
 
 ## Ports
 
-| Port | Service |
-|------|---------|
-| 8090 | Sandbox Manager API |
-| 6100-6200 | Individual sandbox noVNC ports |
+| Range | Service |
+|-------|---------|
+| `8090` | Sandbox Manager API |
+| `6100–6200` | noVNC (web remote desktop) per sandbox |
+| `7100–7200` | Bridge API per sandbox |
 
-## Firewall
+---
 
-```bash
-sudo ufw allow 8090/tcp
-sudo ufw allow 6100:6200/tcp
-```
-
-## Features
-
-- **Isolation**: Each sandbox runs in its own Docker container
-- **Auto-cleanup**: Sandboxes older than 2 hours are automatically removed
-- **Port management**: Automatic port allocation from pool (6100-6200)
-- **Desktop environment**: XFCE + Zed IDE + Firefox
-- **Browser access**: noVNC for web-based remote desktop
-
-## Desktop Environment
-
-Each sandbox includes:
-- Ubuntu 24.04
-- XFCE Desktop
-- Zed IDE
-- Firefox
-- Terminal
-
-## Maintenance Commands
-
-### Service Management
+## Manager service management
 
 ```bash
-# Check API service status
+# Status
 sudo systemctl status devpilot-sandbox
 
-# Restart API service
-sudo systemctl restart devpilot-sandbox
-
-# Stop API service
-sudo systemctl stop devpilot-sandbox
-
-# Start API service
-sudo systemctl start devpilot-sandbox
-
-# View API logs (follow)
+# Logs (live)
 journalctl -u devpilot-sandbox -f
 
-# View last 50 API log lines
+# Last 50 lines
 journalctl -u devpilot-sandbox -n 50 --no-pager
+
+# Restart
+sudo systemctl restart devpilot-sandbox
 ```
 
-### Container Cleanup
+Or use the helper script installed at `/opt/devpilot-sandbox/run.sh`:
 
 ```bash
-# List all sandbox containers
+cd /opt/devpilot-sandbox
+./run.sh status
+./run.sh logs
+./run.sh start
+./run.sh stop
+./run.sh rebuild    # Rebuild desktop Docker image
+./run.sh cleanup    # Remove all sandbox containers
+```
+
+---
+
+## Container management
+
+```bash
+# List running sandbox containers
 docker ps --filter "name=sandbox-"
 
+# View logs for a specific container
+docker logs <container_id>
+
+# Open a shell inside a container
+docker exec -it <container_id> bash
+
+# Check environment variables in container
+docker exec <container_id> env | grep -E "REPO|DEVPILOT|SANDBOX"
+
 # Stop all sandbox containers
-docker stop $(docker ps -q --filter "name=sandbox-")
-
-# Remove all sandbox containers (stopped and running)
-docker rm -f $(docker ps -aq --filter "name=sandbox-")
-
-# Full cleanup: stop + remove all sandbox containers
 docker ps -q --filter "name=sandbox-" | xargs -r docker stop
-docker ps -aq --filter "name=sandbox-" | xargs -r docker rm
+
+# Remove all sandbox containers
+docker ps -aq --filter "name=sandbox-" | xargs -r docker rm -f
 ```
 
-### Image Management
+---
+
+## Full reset
 
 ```bash
-# List sandbox images
-docker images | grep devpilot
-
-# Remove sandbox image (forces rebuild on next setup)
-docker rmi devpilot-desktop
-
-# Rebuild image
-cd /opt/devpilot-sandbox
-docker build -t devpilot-desktop ./desktop
-```
-
-### Volume Cleanup
-
-```bash
-# List all volumes
-docker volume ls
-
-# Remove unused volumes
-docker volume prune -f
-
-# Remove all unused Docker data (containers, images, volumes, networks)
-docker system prune -af --volumes
-```
-
-### Full Reset
-
-```bash
-# Complete reset: stop service, remove all containers/images, rebuild
+# Stop service
 sudo systemctl stop devpilot-sandbox
+
+# Remove all containers and image
 docker rm -f $(docker ps -aq --filter "name=sandbox-") 2>/dev/null
 docker rmi devpilot-desktop 2>/dev/null
 docker volume prune -f
-cd /opt/devpilot-sandbox
-./setup.sh
-sudo systemctl start devpilot-sandbox
+
+# Redeploy
+sudo bash setup.sh
 ```
 
-### Quick Restart (after code changes)
-
-```bash
-# After updating setup.sh locally, copy and redeploy:
-cd /opt/devpilot-sandbox
-./setup.sh
-sudo systemctl restart devpilot-sandbox
-```
+---
 
 ## Troubleshooting
 
-### Check manager status
+### Manager not responding on port 8090
+
 ```bash
-systemctl status devpilot-sandbox
+sudo systemctl status devpilot-sandbox
+curl http://localhost:8090/health
+lsof -i :8090
 ```
 
-### View logs
+### 401 Unauthorized from Bridge API
+
+- Verify the `sandbox_token` in the request matches the one returned at creation
+- The token is per-sandbox and is regenerated every time a new container is created
+
+### 401 Unauthorized from Manager API
+
+- Check `X-Api-Key` matches the value in `/opt/devpilot-sandbox/.env`
+- Key is regenerated each time `setup.sh` runs — update `appsettings.json` accordingly
+
+### Zed not starting inside container
+
 ```bash
-journalctl -u devpilot-sandbox -f
-```
-
-### Debug a running container
-```bash
-# Get container ID
-docker ps --filter "name=sandbox-"
-
-# View container logs
-docker logs <container_id>
-
-# Check environment variables
-docker exec <container_id> env | grep -E "OPENAI|ZED|REPO|DEVPILOT"
-
-# Check Zed settings
-docker exec <container_id> cat /home/sandbox/.config/zed/settings.json
-
-# Check debug log
-docker exec <container_id> cat /tmp/sandbox-debug.log
-
-# Check Zed errors
-docker exec <container_id> cat /tmp/zed-errors.log
-
-# Check if Zed is running
-docker exec <container_id> ps aux | grep zed
-
-# Open shell in container
-docker exec -it <container_id> bash
-```
-
-### Common Issues
-
-**Zed not starting:**
-```bash
-# Run Zed manually to see errors
 docker exec -it <container_id> bash -c '
   source /tmp/dbus-env.sh
   export DISPLAY=:0 LIBGL_ALWAYS_SOFTWARE=1 HOME=/home/sandbox
   /home/sandbox/.local/bin/zed --foreground /home/sandbox/projects 2>&1
 '
+
+# Check startup logs
+docker exec <container_id> cat /tmp/sandbox-debug.log
+docker exec <container_id> cat /tmp/zed-errors.log
 ```
 
-**Port already in use:**
+### VNC blank screen
+
 ```bash
-# Find what's using the port
-lsof -i :8090
-netstat -tlnp | grep 8090
+# Check x11vnc is running
+docker exec <container_id> ps aux | grep x11vnc
 
-# Kill the process
-kill -9 <PID>
-```
-
-**API not responding:**
-```bash
-# Check if service is running
-systemctl status devpilot-sandbox
-
-# Check if port is open
-curl http://localhost:8090/health
+# Check Xvfb is running
+docker exec <container_id> ps aux | grep Xvfb
 ```

--- a/infra/sandbox/linux/README.md
+++ b/infra/sandbox/linux/README.md
@@ -1,0 +1,125 @@
+# DevPilot Sandbox — Linux Setup
+
+Deploy the sandbox manager on a **Linux VPS** as a systemd service.
+
+## Prerequisites
+
+- Ubuntu 22.04 / 24.04 (recommended)
+- Root access (`sudo`)
+- Ports open: `8090`, `6100–6200`, `7100–7200`
+- Docker will be installed automatically if not present
+
+## Quick Start
+
+```bash
+# From the repo root
+sudo bash infra/sandbox/linux/setup.sh
+
+# Or directly on your VPS (download and run)
+curl -sSL https://raw.githubusercontent.com/YOUR_ORG/andy-devpilot/main/infra/sandbox/setup.sh | sudo bash
+```
+
+## What it does
+
+1. Installs Docker (if not already installed)
+2. Creates project directory at `/opt/devpilot-sandbox/`
+3. Generates `MANAGER_API_KEY` in `/opt/devpilot-sandbox/.env`
+4. Copies custom certificates from `infra/sandbox/certs/` into the Docker build context
+5. Builds the `devpilot-desktop` Docker image (~10-20 min first time)
+6. Installs and starts a **systemd service** (`devpilot-sandbox`)
+
+## After setup
+
+### Retrieve the API key
+
+```bash
+sudo cat /opt/devpilot-sandbox/.env
+# MANAGER_API_KEY=<your_key>
+```
+
+### Configure the backend
+
+In `backend/src/API/appsettings.json`:
+
+```json
+"VPS": {
+  "GatewayUrl": "http://YOUR_VPS_IP:8090",
+  "ManagerApiKey": "<MANAGER_API_KEY>",
+  "PublicIp": "YOUR_VPS_PUBLIC_IP",
+  "Enabled": true
+}
+```
+
+## Service management
+
+```bash
+# Status
+sudo systemctl status devpilot-sandbox
+
+# Live logs
+journalctl -u devpilot-sandbox -f
+
+# Restart
+sudo systemctl restart devpilot-sandbox
+
+# Stop
+sudo systemctl stop devpilot-sandbox
+```
+
+Or use the helper script installed at `/opt/devpilot-sandbox/run.sh`:
+
+```bash
+cd /opt/devpilot-sandbox
+sudo ./run.sh status
+sudo ./run.sh logs
+sudo ./run.sh rebuild   # rebuild desktop image
+sudo ./run.sh cleanup   # remove all sandbox containers
+```
+
+## Firewall
+
+```bash
+# Allow sandbox ports (adjust if you use a different firewall)
+sudo ufw allow 8090/tcp          # manager API  (restrict to backend IP if possible)
+sudo ufw allow 6100:6200/tcp     # noVNC per sandbox
+sudo ufw allow 7100:7200/tcp     # Bridge API per sandbox
+sudo ufw reload
+```
+
+> **Security tip:** Port 8090 should only accept connections from your backend server IP.  
+> Example: `sudo ufw allow from <BACKEND_IP> to any port 8090`
+
+## Re-deploy after code changes
+
+```bash
+# Pull latest and re-run setup
+git pull
+sudo bash infra/sandbox/linux/setup.sh
+```
+
+The script stops the service, rebuilds the image, and restarts everything.
+
+## Corporate proxy / Zscaler certificates
+
+Place your `.crt` files in `infra/sandbox/certs/` **before** running setup.  
+See `infra/sandbox/certs/README.md` for instructions.
+
+## Troubleshooting
+
+```bash
+# Manager not responding
+curl http://localhost:8090/health
+sudo systemctl status devpilot-sandbox
+
+# View container logs
+docker logs <container_id>
+
+# Open shell inside a sandbox
+docker exec -it <container_id> bash
+
+# Full reset
+sudo systemctl stop devpilot-sandbox
+docker rm -f $(docker ps -aq --filter "name=sandbox-") 2>/dev/null
+docker rmi devpilot-desktop 2>/dev/null
+sudo bash infra/sandbox/linux/setup.sh
+```

--- a/infra/sandbox/linux/setup.sh
+++ b/infra/sandbox/linux/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# DevPilot Sandbox — Linux entry point
+# Delegates to the shared setup.sh at the parent directory.
+# Must be run as root (sudo) on a Linux VPS.
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "[ERROR] This script must be run as root. Use: sudo bash setup.sh"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$SCRIPT_DIR/../setup.sh" "$@"

--- a/infra/sandbox/mac/README.md
+++ b/infra/sandbox/mac/README.md
@@ -1,0 +1,153 @@
+# DevPilot Sandbox — macOS Setup
+
+Run the sandbox manager locally on **macOS** for development.  
+No systemd — the manager runs as a background process.
+
+## Prerequisites
+
+- macOS 12+ (Monterey or later)
+- **Docker Desktop for Mac** installed and running
+  - Download: https://www.docker.com/products/docker-desktop
+- Bash 4+ (macOS ships with Bash 3 — install via Homebrew if needed: `brew install bash`)
+- Do **not** run with `sudo`
+
+## Quick Start
+
+```bash
+# From the repo root
+bash infra/sandbox/mac/setup.sh
+```
+
+The manager installs to `~/.devpilot-sandbox/` and starts in the background.
+
+## What it does
+
+1. Checks that Docker Desktop is running
+2. Creates `~/.devpilot-sandbox/` 
+3. Generates `MANAGER_API_KEY` in `~/.devpilot-sandbox/.env`
+4. Copies custom certificates from `infra/sandbox/certs/`
+5. Builds the `devpilot-desktop` Docker image (~10-20 min first time)
+6. Starts the manager as a **background process** (PID saved to `~/.devpilot-sandbox/manager.pid`)
+
+## After setup
+
+### Retrieve the API key
+
+```bash
+cat ~/.devpilot-sandbox/.env
+# MANAGER_API_KEY=<your_key>
+```
+
+### Configure the backend
+
+In `backend/src/API/appsettings.Development.json`:
+
+```json
+"VPS": {
+  "GatewayUrl": "http://localhost:8090",
+  "ManagerApiKey": "<MANAGER_API_KEY>",
+  "PublicIp": "localhost",
+  "Enabled": true
+}
+```
+
+## Manager management
+
+```bash
+cd ~/.devpilot-sandbox
+
+# Status
+./run.sh status
+
+# Live logs
+./run.sh logs
+
+# Stop manager
+./run.sh stop
+
+# Start manager
+./run.sh start
+
+# Rebuild desktop image
+./run.sh rebuild
+```
+
+Or manage manually:
+
+```bash
+# Check if running
+ps aux | grep manager.py
+
+# View logs
+tail -f ~/.devpilot-sandbox/manager.log
+
+# Kill manager
+kill $(cat ~/.devpilot-sandbox/manager.pid)
+```
+
+## Re-deploy after code changes
+
+```bash
+# Pull latest and re-run setup
+git pull
+bash infra/sandbox/mac/setup.sh
+```
+
+## Corporate proxy / Zscaler certificates
+
+Place your `.crt` files in `infra/sandbox/certs/` **before** running setup.  
+See `infra/sandbox/certs/README.md` for how to export your corporate root CA.
+
+## Troubleshooting
+
+### Manager not starting
+
+```bash
+# Check Docker Desktop is running
+docker info
+
+# Check port 8090
+lsof -i :8090
+
+# Run manager manually to see errors
+cd ~/.devpilot-sandbox
+source .env
+./venv/bin/python manager.py
+```
+
+### Desktop image build fails
+
+```bash
+# Rebuild with full output
+bash infra/sandbox/mac/setup.sh
+
+# Or rebuild manually
+cd ~/.devpilot-sandbox
+docker build -t devpilot-desktop ./desktop
+```
+
+### Container cleanup
+
+```bash
+# List running sandbox containers
+docker ps --filter "name=sandbox-"
+
+# Stop all sandbox containers
+docker ps -q --filter "name=sandbox-" | xargs -r docker stop
+docker ps -aq --filter "name=sandbox-" | xargs -r docker rm
+```
+
+### Full reset
+
+```bash
+# Stop manager
+kill $(cat ~/.devpilot-sandbox/manager.pid) 2>/dev/null
+
+# Remove containers and image
+docker rm -f $(docker ps -aq --filter "name=sandbox-") 2>/dev/null
+docker rmi devpilot-desktop 2>/dev/null
+
+# Clean install
+rm -rf ~/.devpilot-sandbox
+bash infra/sandbox/mac/setup.sh
+```

--- a/infra/sandbox/mac/setup.sh
+++ b/infra/sandbox/mac/setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# DevPilot Sandbox — macOS entry point
+# Delegates to the shared setup.sh at the parent directory.
+# Do NOT run with sudo on macOS (installs to ~/.devpilot-sandbox/).
+
+set -e
+
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "[ERROR] This script is for macOS only."
+    echo "        Linux users: use infra/sandbox/linux/setup.sh"
+    echo "        Windows users: use infra/sandbox/windows/setup.ps1"
+    exit 1
+fi
+
+if [ "$(id -u)" -eq 0 ]; then
+    echo "[WARN] Running as root on macOS is not recommended."
+    echo "       The sandbox will install to /root/.devpilot-sandbox instead of your home directory."
+    read -p "Continue anyway? [y/N] " answer
+    [[ "$answer" =~ ^[Yy]$ ]] || exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$SCRIPT_DIR/../setup.sh" "$@"

--- a/infra/sandbox/setup.sh
+++ b/infra/sandbox/setup.sh
@@ -845,7 +845,28 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
-CORS(app)
+CORS(app, resources={r"/*": {"origins": "*", "allow_headers": ["Authorization", "Content-Type"]}})
+
+# Per-sandbox token — injected as SANDBOX_TOKEN env var by the manager at container creation
+SANDBOX_TOKEN = os.environ.get('SANDBOX_TOKEN', '')
+
+@app.before_request
+def require_token():
+    """
+    Protect all external-facing routes with the sandbox bearer token.
+    Exemptions:
+    - OPTIONS requests: CORS preflight — browsers never send auth headers here
+    - /v1/* routes: OpenAI proxy called by Zed from inside the container on localhost
+    """
+    if not SANDBOX_TOKEN:
+        return  # Auth disabled when no token configured
+    if request.method == 'OPTIONS':
+        return  # Let Flask-CORS handle preflight freely
+    if request.path.startswith('/v1/'):
+        return  # Zed internal calls — no auth header available
+    auth = request.headers.get('Authorization', '')
+    if auth != f'Bearer {SANDBOX_TOKEN}':
+        return jsonify({'error': 'Unauthorized'}), 401
 
 # SSL Configuration - try to fix SSL issues in sandbox
 SSL_CERT_FILE = os.environ.get('SSL_CERT_FILE', '/etc/ssl/certs/ca-certificates.crt')
@@ -2527,7 +2548,7 @@ sleep 1
 echo "Panel restarted with Terminal, Firefox, Zed" >> /tmp/sandbox-debug.log
 
 # Start VNC server
-x11vnc -display $DISPLAY -forever -shared -rfbport 5900 -nopw -xkb &
+x11vnc -display $DISPLAY -forever -shared -rfbport 5900 -passwd "${VNC_PASSWORD:-devpilot}" -xkb &
 sleep 1
 
 # Start websockify on internal port 6081
@@ -2880,8 +2901,10 @@ from flask import Flask, jsonify, request
 from flask_cors import CORS
 import docker
 import uuid
+import secrets
 import threading
 import time
+import os
 
 app = Flask(__name__)
 CORS(app)
@@ -2890,12 +2913,23 @@ SANDBOX_MANAGER_VERSION = "2.3.0"  # Bump this when deploying changes
 
 client = docker.from_env()
 
-# Track active sandboxes: {sandbox_id: {container_id, port, created_at}}
+# API key protecting the manager — set via MANAGER_API_KEY env var on the host
+MANAGER_API_KEY = os.environ.get('MANAGER_API_KEY', '')
+
+# Track active sandboxes: {sandbox_id: {container_id, port, created_at, sandbox_token, vnc_password}}
 sandboxes = {}
 PORT_START = 6100
 PORT_END = 6200
 used_ports = set()
 lock = threading.Lock()
+
+def require_api_key():
+    """Return a 401 response if the request does not include a valid X-Api-Key header."""
+    if MANAGER_API_KEY:
+        provided = request.headers.get('X-Api-Key', '')
+        if provided != MANAGER_API_KEY:
+            return jsonify({'error': 'Unauthorized'}), 401
+    return None
 
 def get_free_port():
     """Get next available port"""
@@ -2922,6 +2956,9 @@ def health():
 @app.route('/sandboxes', methods=['GET'])
 def list_sandboxes():
     """List all active sandboxes"""
+    err = require_api_key()
+    if err:
+        return err
     result = []
     for sid, info in sandboxes.items():
         try:
@@ -2929,6 +2966,7 @@ def list_sandboxes():
             result.append({
                 "id": sid,
                 "port": info['port'],
+                "bridge_port": info.get('bridge_port', 0),
                 "status": container.status,
                 "created_at": info['created_at']
             })
@@ -2939,6 +2977,10 @@ def list_sandboxes():
 @app.route('/sandboxes', methods=['POST'])
 def create_sandbox():
     """Create a new isolated sandbox with optional repo and AI config"""
+    err = require_api_key()
+    if err:
+        return err
+
     import json
     
     # Log incoming request
@@ -2950,6 +2992,10 @@ def create_sandbox():
     
     sandbox_id = str(uuid.uuid4())[:8]
     port = get_free_port()
+    # Per-sandbox secrets generated at creation time
+    sandbox_token = secrets.token_urlsafe(32)
+    # VNC passwords are limited to 8 chars by the VNC protocol
+    vnc_password = secrets.token_urlsafe(8)[:8]
     
     if not port:
         return jsonify({"error": "No ports available"}), 503
@@ -2960,7 +3006,9 @@ def create_sandbox():
         # Build environment variables
         environment = {
             "SANDBOX_ID": sandbox_id,
-            "RESOLUTION": data.get("resolution", "1920x1080x24")
+            "RESOLUTION": data.get("resolution", "1920x1080x24"),
+            "SANDBOX_TOKEN": sandbox_token,
+            "VNC_PASSWORD": vnc_password,
         }
         
         # Add repository info if provided
@@ -3081,7 +3129,9 @@ def create_sandbox():
             "container_id": container.id,
             "port": port,
             "bridge_port": bridge_port,
-            "created_at": time.time()
+            "created_at": time.time(),
+            "sandbox_token": sandbox_token,
+            "vnc_password": vnc_password,
         }
         
         return jsonify({
@@ -3090,7 +3140,9 @@ def create_sandbox():
             "bridge_port": bridge_port,
             "url": f"http://HOST_IP:{port}/vnc.html",
             "bridge_url": f"http://HOST_IP:{bridge_port}",
-            "status": "starting"
+            "status": "starting",
+            "sandbox_token": sandbox_token,
+            "vnc_password": vnc_password,
         }), 201
         
     except Exception as e:
@@ -3100,6 +3152,9 @@ def create_sandbox():
 @app.route('/sandboxes/<sandbox_id>', methods=['GET'])
 def get_sandbox(sandbox_id):
     """Get sandbox status"""
+    err = require_api_key()
+    if err:
+        return err
     if sandbox_id not in sandboxes:
         return jsonify({"error": "Sandbox not found"}), 404
     
@@ -3117,6 +3172,9 @@ def get_sandbox(sandbox_id):
 @app.route('/sandboxes/<sandbox_id>', methods=['DELETE'])
 def delete_sandbox(sandbox_id):
     """Stop and remove a sandbox"""
+    err = require_api_key()
+    if err:
+        return err
     if sandbox_id not in sandboxes:
         return jsonify({"error": "Sandbox not found"}), 404
     
@@ -3136,6 +3194,9 @@ def delete_sandbox(sandbox_id):
 @app.route('/sandboxes/<sandbox_id>/stop', methods=['POST'])
 def stop_sandbox(sandbox_id):
     """Stop a sandbox (keep container)"""
+    err = require_api_key()
+    if err:
+        return err
     if sandbox_id not in sandboxes:
         return jsonify({"error": "Sandbox not found"}), 404
     
@@ -3177,6 +3238,17 @@ if __name__ == '__main__':
 MANAGER_PY
 
 # ============================================================
+# BUILD_ONLY mode — used by Windows Docker setup (setup.ps1)
+# Exits here after building the desktop image and writing manager.py.
+# The Windows setup starts the manager via docker-compose instead of systemd.
+# ============================================================
+if [ "${BUILD_ONLY:-0}" = "1" ]; then
+    log_success "BUILD_ONLY mode complete — desktop image built, manager.py ready."
+    log_info "Start the manager on Windows with: docker compose up -d"
+    exit 0
+fi
+
+# ============================================================
 # Create systemd service for the manager (Linux only)
 # ============================================================
 if [ "$IS_LINUX" = true ]; then
@@ -3195,6 +3267,7 @@ ExecStart=$PROJECT_DIR/venv/bin/python $PROJECT_DIR/manager.py
 Restart=always
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
+EnvironmentFile=-$PROJECT_DIR/.env
 
 [Install]
 WantedBy=multi-user.target
@@ -3328,6 +3401,21 @@ RUNSH
 chmod +x run.sh
 
 # ============================================================
+# Generate .env with a random MANAGER_API_KEY (only if not already set)
+# ============================================================
+if [ ! -f "$PROJECT_DIR/.env" ]; then
+    log_info "Generating .env with random MANAGER_API_KEY..."
+    GENERATED_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+    cat > "$PROJECT_DIR/.env" << ENVFILE
+MANAGER_API_KEY=${GENERATED_KEY}
+ENVFILE
+    chmod 600 "$PROJECT_DIR/.env"
+    log_info "API key saved to $PROJECT_DIR/.env"
+else
+    log_skip ".env already exists — keeping existing MANAGER_API_KEY"
+fi
+
+# ============================================================
 # Start the service
 # ============================================================
 log_info "Starting sandbox manager..."
@@ -3362,12 +3450,16 @@ echo "   GET    /sandboxes/{id}     - Get sandbox status"
 echo "   DELETE /sandboxes/{id}     - Delete sandbox"
 echo ""
 echo "📌 Example:"
-echo "   curl -X POST http://${PUBLIC_IP}:8090/sandboxes"
+echo "   curl -X POST http://${PUBLIC_IP}:8090/sandboxes \\"
+echo "        -H 'X-Api-Key: \$(grep MANAGER_API_KEY $PROJECT_DIR/.env | cut -d= -f2)'"
 echo ""
 echo "🔧 Management:"
 echo "   cd $PROJECT_DIR"
 echo "   ./run.sh status"
 echo "   ./run.sh logs"
+echo ""
+echo "🔑 Manager API Key (for backend config VPS:ManagerApiKey):"
+echo "   \$(grep MANAGER_API_KEY $PROJECT_DIR/.env | cut -d= -f2)"
 echo ""
 echo "⚠️  Firewall: Open ports 8090 and 6100-6200"
 echo "   ufw allow 8090/tcp"

--- a/infra/sandbox/windows/.gitignore
+++ b/infra/sandbox/windows/.gitignore
@@ -1,0 +1,2 @@
+# Generated API key — never commit
+.env

--- a/infra/sandbox/windows/Dockerfile.manager
+++ b/infra/sandbox/windows/Dockerfile.manager
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir flask flask-cors docker
+
+COPY manager.py .
+
+EXPOSE 8090
+
+CMD ["python", "manager.py"]

--- a/infra/sandbox/windows/README.md
+++ b/infra/sandbox/windows/README.md
@@ -1,0 +1,149 @@
+# DevPilot Sandbox — Windows Setup
+
+Run the sandbox system on Windows using Docker Desktop **without WSL**.
+
+## How it works
+
+On Linux, `setup.sh` installs the sandbox manager as a **systemd service**.  
+On Windows, this setup replaces that with a **Docker container** running the manager — no WSL terminal needed.
+
+```
+PowerShell (setup.ps1)
+       │
+       ├── Builds devpilot-desktop image
+       │   └── Runs setup.sh inside a Linux Docker container (BUILD_ONLY=1)
+       │       └── docker build uses the Windows Docker Desktop named pipe
+       │
+       └── Starts manager container (docker-compose)
+               └── manager.py → mounts \\.\pipe\docker_engine
+                   └── Creates/destroys sandbox containers on demand
+```
+
+## Prerequisites
+
+- **Docker Desktop for Windows** (Hyper-V or WSL2 backend — both work)
+  - Download: https://www.docker.com/products/docker-desktop
+  - Enable "Use the WSL 2 based engine" OR keep Hyper-V (both work)
+  - Make sure **Linux containers** mode is selected (default)
+- **PowerShell 5.1+** (included in Windows 10/11)
+- Ports **8090**, **6100–6200**, **7100–7200** free on your machine
+
+## Quick Start
+
+Open **PowerShell** (not CMD) in the repo root:
+
+```powershell
+# First time setup (builds the desktop image — takes 10-20 min)
+.\infra\sandbox\windows\setup.ps1
+
+# If the backend runs on a different machine or you need a specific IP
+.\infra\sandbox\windows\setup.ps1 -HostIP 192.168.1.50
+
+# Force a full rebuild of the desktop image
+.\infra\sandbox\windows\setup.ps1 -Rebuild
+```
+
+If you get a script execution error, run this first:
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+```
+
+## What setup.ps1 does
+
+1. **Checks Docker Desktop** is running
+2. **Builds `devpilot-desktop`** by running `setup.sh` inside a temporary Linux container that mounts the Docker named pipe (`\\.\pipe\docker_engine`) — this builds the image on your host Docker without WSL
+3. **Generates an API key** and writes it to `windows/.env`
+4. **Starts the manager** container via `docker compose up`
+5. **Health checks** the manager at `http://localhost:8090/health`
+
+## Configure the backend
+
+After running setup, update `backend/src/API/appsettings.Development.json`:
+
+```json
+"VPS": {
+  "GatewayUrl": "http://localhost:8090",
+  "ManagerApiKey": "<key shown in setup output>",
+  "PublicIp": "localhost",
+  "Enabled": true
+}
+```
+
+The API key is also saved in `windows/.env` (gitignored).
+
+## Day-to-day management
+
+```powershell
+# Start the manager (after PC restart)
+docker compose -f infra\sandbox\windows\docker-compose.yml up -d
+
+# Stop the manager
+docker compose -f infra\sandbox\windows\docker-compose.yml down
+
+# Live manager logs
+docker logs -f devpilot-sandbox-manager
+
+# List running sandbox containers
+docker ps --filter "name=sandbox-"
+
+# Stop and remove all sandbox containers
+docker ps -q --filter "name=sandbox-" | ForEach-Object { docker stop $_ }
+docker ps -aq --filter "name=sandbox-" | ForEach-Object { docker rm $_ }
+```
+
+## Start manager automatically on Windows startup
+
+```powershell
+# Register a scheduled task that starts the manager at login
+$action  = New-ScheduledTaskAction -Execute "docker" -Argument "compose -f `"$PWD\infra\sandbox\windows\docker-compose.yml`" up -d"
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+Register-ScheduledTask -TaskName "DevPilot Sandbox Manager" -Action $action -Trigger $trigger -RunLevel Highest
+```
+
+## Troubleshooting
+
+### "docker: error during connect" / manager won't start
+
+- Make sure Docker Desktop is running (check the system tray icon)
+- Switch to Linux containers mode in Docker Desktop
+
+### Desktop image build fails
+
+```powershell
+# Check what went wrong — run with verbose output
+docker run --rm `
+  -v "//./pipe/docker_engine://./pipe/docker_engine" `
+  -v "${PWD}\infra\sandbox:/workspace" `
+  -e BUILD_ONLY=1 `
+  ubuntu:24.04 `
+  bash -c "apt-get install -y docker.io curl wget git -qq && bash /workspace/setup.sh"
+```
+
+### Named pipe error on older Docker Desktop
+
+Some older versions require the legacy pipe name. Edit `docker-compose.yml` and change:
+```yaml
+source: \\.\pipe\docker_engine
+# to:
+source: \\.\pipe\docker_engine_linux
+```
+
+### Sandbox containers don't appear
+
+```powershell
+# Check manager logs for errors
+docker logs devpilot-sandbox-manager
+
+# Verify the desktop image exists
+docker images devpilot-desktop
+```
+
+## Files in this folder
+
+| File | Purpose |
+|------|---------|
+| `setup.ps1` | One-click Windows setup script |
+| `docker-compose.yml` | Runs the manager as a Docker container |
+| `Dockerfile.manager` | Manager container image (Python + Flask + docker SDK) |
+| `manager.py` | Standalone manager (same logic as embedded in `setup.sh`) |
+| `.env` | Generated API key (gitignored) |

--- a/infra/sandbox/windows/docker-compose.yml
+++ b/infra/sandbox/windows/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  sandbox-manager:
+    build:
+      context: .
+      dockerfile: Dockerfile.manager
+    image: devpilot-sandbox-manager
+    container_name: devpilot-sandbox-manager
+    ports:
+      - "8090:8090"
+    volumes:
+      # Mount the Windows Docker Desktop named pipe so the manager can create sibling containers
+      - type: npipe
+        source: \\.\pipe\docker_engine
+        target: /var/run/docker.sock
+    env_file:
+      - .env
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8090/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/infra/sandbox/windows/manager.py
+++ b/infra/sandbox/windows/manager.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+DevPilot Sandbox Manager
+Simple API to create/destroy isolated desktop containers
+"""
+
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+import docker
+import uuid
+import secrets
+import threading
+import time
+import os
+
+app = Flask(__name__)
+CORS(app)
+
+SANDBOX_MANAGER_VERSION = "2.3.0"
+
+client = docker.from_env()
+
+# API key protecting the manager — set via MANAGER_API_KEY env var
+MANAGER_API_KEY = os.environ.get('MANAGER_API_KEY', '')
+
+# Track active sandboxes: {sandbox_id: {container_id, port, bridge_port, created_at, sandbox_token, vnc_password}}
+sandboxes = {}
+PORT_START = 6100
+PORT_END = 6200
+used_ports = set()
+lock = threading.Lock()
+
+def require_api_key():
+    """Return a 401 response if the request does not include a valid X-Api-Key header."""
+    if MANAGER_API_KEY:
+        provided = request.headers.get('X-Api-Key', '')
+        if provided != MANAGER_API_KEY:
+            return jsonify({'error': 'Unauthorized'}), 401
+    return None
+
+def get_free_port():
+    """Get next available port"""
+    with lock:
+        for port in range(PORT_START, PORT_END):
+            if port not in used_ports:
+                used_ports.add(port)
+                return port
+    return None
+
+def release_port(port):
+    """Release a port back to the pool"""
+    with lock:
+        used_ports.discard(port)
+
+@app.route('/health', methods=['GET'])
+def health():
+    return jsonify({
+        "status": "ok",
+        "version": SANDBOX_MANAGER_VERSION,
+        "active_sandboxes": len(sandboxes)
+    })
+
+@app.route('/sandboxes', methods=['GET'])
+def list_sandboxes():
+    """List all active sandboxes"""
+    err = require_api_key()
+    if err:
+        return err
+    result = []
+    for sid, info in sandboxes.items():
+        try:
+            container = client.containers.get(info['container_id'])
+            result.append({
+                "id": sid,
+                "port": info['port'],
+                "bridge_port": info.get('bridge_port', 0),
+                "status": container.status,
+                "created_at": info['created_at']
+            })
+        except:
+            pass
+    return jsonify({"sandboxes": result})
+
+@app.route('/sandboxes', methods=['POST'])
+def create_sandbox():
+    """Create a new isolated sandbox with optional repo and AI config"""
+    err = require_api_key()
+    if err:
+        return err
+
+    import json
+
+    print("=" * 50)
+    print(f"CREATE SANDBOX REQUEST (Manager v{SANDBOX_MANAGER_VERSION})")
+    print("=" * 50)
+    print(f"Request JSON: {request.json}")
+    print("=" * 50)
+
+    sandbox_id = str(uuid.uuid4())[:8]
+    port = get_free_port()
+    sandbox_token = secrets.token_urlsafe(32)
+    vnc_password = secrets.token_urlsafe(8)[:8]
+
+    if not port:
+        return jsonify({"error": "No ports available"}), 503
+
+    try:
+        data = request.json or {}
+
+        environment = {
+            "SANDBOX_ID": sandbox_id,
+            "RESOLUTION": data.get("resolution", "1920x1080x24"),
+            "SANDBOX_TOKEN": sandbox_token,
+            "VNC_PASSWORD": vnc_password,
+        }
+
+        repo_url = data.get("repo_url", "")
+        github_token = data.get("github_token", "")
+
+        if repo_url and github_token and "github.com" in repo_url:
+            repo_url = repo_url.replace("https://github.com/", f"https://{github_token}@github.com/")
+
+        if repo_url:
+            environment["REPO_URL"] = repo_url
+        if data.get("repo_name"):
+            environment["REPO_NAME"] = data["repo_name"]
+        if data.get("repo_branch"):
+            environment["REPO_BRANCH"] = data["repo_branch"]
+        if data.get("repo_archive_url"):
+            environment["REPO_ARCHIVE_URL"] = data["repo_archive_url"]
+
+        if data.get("ai_config"):
+            ai = data["ai_config"]
+            provider = ai.get("provider", "openai")
+            model = ai.get("model", "gpt-4o")
+            api_key = ai.get("api_key", "")
+            base_url = ai.get("base_url", "")
+
+            environment["DEVPILOT_MODEL"] = model
+            environment["DEVPILOT_PROVIDER"] = provider
+
+            if api_key:
+                if provider == "openai":
+                    environment["OPENAI_API_KEY"] = api_key
+                elif provider == "anthropic":
+                    environment["ANTHROPIC_API_KEY"] = api_key
+                elif provider == "custom":
+                    environment["OPENAI_API_KEY"] = api_key
+                    if base_url:
+                        environment["OPENAI_API_BASE"] = base_url
+
+            if data.get("zed_settings"):
+                environment["ZED_SETTINGS_JSON"] = json.dumps(data["zed_settings"], indent=2)
+            else:
+                zed_provider = "openai" if provider == "custom" else provider
+                settings = {
+                    "theme": "One Dark",
+                    "ui_font_size": 14,
+                    "buffer_font_size": 14,
+                    "agent": {
+                        "enabled": True,
+                        "default_model": {"provider": zed_provider, "model": model},
+                        "always_allow_tool_actions": True
+                    },
+                    "features": {"edit_prediction_provider": "zed"},
+                    "terminal": {"env": {"LIBGL_ALWAYS_SOFTWARE": "1"}},
+                    "worktree": {"trust_by_default": True}
+                }
+
+                if provider == "ollama":
+                    settings["language_models"] = {
+                        "ollama": {"api_url": ai.get("base_url", "http://localhost:11434")}
+                    }
+                else:
+                    settings["language_models"] = {
+                        "openai": {
+                            "api_url": "http://localhost:8091/v1",
+                            "available_models": [
+                                {"name": model, "display_name": model, "max_tokens": 128000}
+                            ]
+                        }
+                    }
+
+                environment["ZED_SETTINGS_JSON"] = json.dumps(settings, indent=2)
+        elif data.get("zed_settings"):
+            environment["ZED_SETTINGS_JSON"] = json.dumps(data["zed_settings"], indent=2)
+
+        safe_env = {k: ('***' if 'KEY' in k or 'TOKEN' in k else v) for k, v in environment.items()}
+        print(f"Environment variables: {safe_env}")
+
+        bridge_port = port + 1000
+
+        container = client.containers.run(
+            "devpilot-desktop",
+            name=f"sandbox-{sandbox_id}",
+            detach=True,
+            remove=False,
+            ports={
+                '6080/tcp': port,
+                '8091/tcp': bridge_port
+            },
+            shm_size="512m",
+            environment=environment
+        )
+
+        sandboxes[sandbox_id] = {
+            "container_id": container.id,
+            "port": port,
+            "bridge_port": bridge_port,
+            "created_at": time.time(),
+            "sandbox_token": sandbox_token,
+            "vnc_password": vnc_password,
+        }
+
+        host_ip = os.environ.get('HOST_IP', 'localhost')
+        return jsonify({
+            "id": sandbox_id,
+            "port": port,
+            "bridge_port": bridge_port,
+            "url": f"http://{host_ip}:{port}/vnc.html",
+            "bridge_url": f"http://{host_ip}:{bridge_port}",
+            "status": "starting",
+            "sandbox_token": sandbox_token,
+            "vnc_password": vnc_password,
+        }), 201
+
+    except Exception as e:
+        release_port(port)
+        return jsonify({"error": str(e)}), 500
+
+@app.route('/sandboxes/<sandbox_id>', methods=['GET'])
+def get_sandbox(sandbox_id):
+    """Get sandbox status"""
+    err = require_api_key()
+    if err:
+        return err
+    if sandbox_id not in sandboxes:
+        return jsonify({"error": "Sandbox not found"}), 404
+
+    info = sandboxes[sandbox_id]
+    try:
+        container = client.containers.get(info['container_id'])
+        return jsonify({
+            "id": sandbox_id,
+            "port": info['port'],
+            "bridge_port": info.get('bridge_port', 0),
+            "status": container.status
+        })
+    except:
+        return jsonify({"error": "Container not found"}), 404
+
+@app.route('/sandboxes/<sandbox_id>', methods=['DELETE'])
+def delete_sandbox(sandbox_id):
+    """Stop and remove a sandbox"""
+    err = require_api_key()
+    if err:
+        return err
+    if sandbox_id not in sandboxes:
+        return jsonify({"error": "Sandbox not found"}), 404
+
+    info = sandboxes[sandbox_id]
+    try:
+        container = client.containers.get(info['container_id'])
+        container.stop(timeout=5)
+        container.remove()
+    except:
+        pass
+
+    release_port(info['port'])
+    del sandboxes[sandbox_id]
+
+    return jsonify({"status": "deleted"})
+
+@app.route('/sandboxes/<sandbox_id>/stop', methods=['POST'])
+def stop_sandbox(sandbox_id):
+    """Stop a sandbox (keep container)"""
+    err = require_api_key()
+    if err:
+        return err
+    if sandbox_id not in sandboxes:
+        return jsonify({"error": "Sandbox not found"}), 404
+
+    info = sandboxes[sandbox_id]
+    try:
+        container = client.containers.get(info['container_id'])
+        container.stop(timeout=5)
+        return jsonify({"status": "stopped"})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+def cleanup_old_sandboxes():
+    while True:
+        time.sleep(300)
+        now = time.time()
+        to_delete = []
+        for sid, info in sandboxes.items():
+            if now - info['created_at'] > 7200:  # 2 hours
+                to_delete.append(sid)
+        for sid in to_delete:
+            try:
+                info = sandboxes[sid]
+                container = client.containers.get(info['container_id'])
+                container.stop(timeout=5)
+                container.remove()
+                release_port(info['port'])
+                del sandboxes[sid]
+                print(f"Cleaned up sandbox {sid}")
+            except:
+                pass
+
+if __name__ == '__main__':
+    threading.Thread(target=cleanup_old_sandboxes, daemon=True).start()
+    print(f"DevPilot Sandbox Manager v{SANDBOX_MANAGER_VERSION} starting on port 8090...")
+    app.run(host='0.0.0.0', port=8090)

--- a/infra/sandbox/windows/setup.ps1
+++ b/infra/sandbox/windows/setup.ps1
@@ -1,0 +1,199 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    DevPilot Sandbox setup for Windows (Docker Desktop, no WSL required).
+
+.DESCRIPTION
+    Builds the devpilot-desktop image and starts the sandbox manager as a
+    Docker container. Docker Desktop must be running (Hyper-V or WSL2 backend).
+
+.PARAMETER HostIP
+    Your machine's IP address that sandbox containers will use for their URLs.
+    Defaults to 'localhost'. Use your LAN IP if the backend runs on another machine.
+
+.PARAMETER Rebuild
+    Force a full rebuild of the devpilot-desktop image (ignores Docker cache).
+
+.EXAMPLE
+    .\setup.ps1
+    .\setup.ps1 -HostIP 192.168.1.50
+    .\setup.ps1 -Rebuild
+#>
+param(
+    [string]$HostIP = "localhost",
+    [switch]$Rebuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+function Write-Step  { param($msg) Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-Ok    { param($msg) Write-Host "  ✓ $msg" -ForegroundColor Green }
+function Write-Warn  { param($msg) Write-Host "  ! $msg" -ForegroundColor Yellow }
+function Write-Fail  { param($msg) Write-Host "  ✗ $msg" -ForegroundColor Red }
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+$windowsDir = $PSScriptRoot
+$sandboxDir  = Split-Path $windowsDir -Parent        # infra/sandbox
+$envFile     = Join-Path $windowsDir ".env"
+
+Write-Host ""
+Write-Host "╔══════════════════════════════════════════╗" -ForegroundColor Magenta
+Write-Host "║   DevPilot Sandbox — Windows Setup       ║" -ForegroundColor Magenta
+Write-Host "╚══════════════════════════════════════════╝" -ForegroundColor Magenta
+Write-Host ""
+
+# ── 1. Check Docker Desktop ───────────────────────────────────────────────────
+Write-Step "Checking Docker Desktop..."
+try {
+    $null = docker info 2>&1
+    Write-Ok "Docker Desktop is running"
+} catch {
+    Write-Fail "Docker Desktop is not running or not installed."
+    Write-Host "  Install from https://www.docker.com/products/docker-desktop" -ForegroundColor Yellow
+    exit 1
+}
+
+# ── 2. Build the devpilot-desktop image ───────────────────────────────────────
+Write-Step "Building devpilot-desktop image (this can take 10-20 min on first run)..."
+
+# Check if image already exists (and skip if not forced)
+$imageExists = docker images -q devpilot-desktop 2>$null
+if ($imageExists -and -not $Rebuild) {
+    Write-Ok "devpilot-desktop image already exists. Use -Rebuild to force a rebuild."
+} else {
+    if ($Rebuild) { Write-Warn "Forcing full rebuild (-Rebuild flag)" }
+
+    # We run setup.sh inside a Linux container that has access to the host Docker socket.
+    # BUILD_ONLY=1 makes setup.sh stop after building the image (skips systemd installation).
+    # The docker build commands inside setup.sh will execute on the HOST Docker daemon
+    # via the mounted named pipe.
+    $setupShPath = (Join-Path $sandboxDir "setup.sh") -replace "\\", "/"
+    # Convert Windows path to Docker-friendly format (e.g. C:\Users\... -> /c/Users/...)
+    $driveLetter = $sandboxDir.Substring(0,1).ToLower()
+    $dockerSandboxDir = "/" + $driveLetter + ($sandboxDir.Substring(2) -replace "\\", "/")
+
+    Write-Host "  Running setup.sh in a Linux build container..." -ForegroundColor Gray
+    Write-Host "  Mounted sandbox dir: $dockerSandboxDir" -ForegroundColor Gray
+
+    $buildArgs = @(
+        "run", "--rm",
+        "-v", "//./pipe/docker_engine://./pipe/docker_engine",
+        "-v", "${sandboxDir}:${dockerSandboxDir}:ro",
+        "-e", "BUILD_ONLY=1",
+        "-e", "SCRIPT_SOURCE_DIR=${dockerSandboxDir}",
+        "-w", $dockerSandboxDir,
+        "ubuntu:24.04",
+        "bash", "-c",
+        "apt-get update -qq 2>/dev/null && apt-get install -y docker.io curl wget git -qq 2>/dev/null && bash setup.sh"
+    )
+
+    $proc = Start-Process -FilePath "docker" -ArgumentList $buildArgs -NoNewWindow -PassThru -Wait
+    if ($proc.ExitCode -ne 0) {
+        Write-Fail "Desktop image build failed (exit code $($proc.ExitCode))."
+        Write-Host "  Check the output above for errors." -ForegroundColor Yellow
+        exit 1
+    }
+
+    # Verify image was built
+    $imageExists = docker images -q devpilot-desktop 2>$null
+    if (-not $imageExists) {
+        Write-Fail "Image 'devpilot-desktop' was not created. Something went wrong."
+        exit 1
+    }
+    Write-Ok "devpilot-desktop image built successfully"
+}
+
+# ── 3. Generate or load API key ───────────────────────────────────────────────
+Write-Step "Configuring API key..."
+
+if (Test-Path $envFile) {
+    $existing = Get-Content $envFile | Where-Object { $_ -match "^MANAGER_API_KEY=" }
+    if ($existing) {
+        $apiKey = ($existing -split "=", 2)[1]
+        Write-Ok "Reusing existing API key from .env"
+    }
+}
+
+if (-not $apiKey) {
+    # Generate a cryptographically random 32-byte key (base64url encoded)
+    $bytes = New-Object byte[] 32
+    [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($bytes)
+    $apiKey = [Convert]::ToBase64String($bytes) -replace "\+", "-" -replace "/", "_" -replace "=", ""
+    Write-Ok "Generated new API key"
+}
+
+# Write .env file
+@"
+MANAGER_API_KEY=$apiKey
+HOST_IP=$HostIP
+"@ | Set-Content $envFile -Encoding UTF8
+
+Write-Ok "Wrote .env (HOST_IP=$HostIP)"
+
+# ── 4. Build manager image and start with docker-compose ──────────────────────
+Write-Step "Starting sandbox manager container..."
+
+Push-Location $windowsDir
+try {
+    # Stop any existing manager
+    docker compose down --remove-orphans 2>$null | Out-Null
+
+    # Build manager image and start
+    $composeArgs = @("compose", "up", "-d", "--build")
+    $proc = Start-Process -FilePath "docker" -ArgumentList $composeArgs -NoNewWindow -PassThru -Wait
+    if ($proc.ExitCode -ne 0) {
+        Write-Fail "Failed to start sandbox manager."
+        exit 1
+    }
+} finally {
+    Pop-Location
+}
+
+# ── 5. Health check ───────────────────────────────────────────────────────────
+Write-Step "Waiting for manager to be ready..."
+$maxWait = 30
+$waited  = 0
+$ready   = $false
+while ($waited -lt $maxWait) {
+    Start-Sleep -Seconds 2
+    $waited += 2
+    try {
+        $response = Invoke-WebRequest -Uri "http://localhost:8090/health" -UseBasicParsing -TimeoutSec 2 -ErrorAction SilentlyContinue
+        if ($response.StatusCode -eq 200) {
+            $ready = $true
+            break
+        }
+    } catch { }
+    Write-Host "  Waiting... ($waited s)" -ForegroundColor Gray
+}
+
+if ($ready) {
+    Write-Ok "Manager is up at http://localhost:8090"
+} else {
+    Write-Warn "Manager did not respond in ${maxWait}s. Check logs: docker logs devpilot-sandbox-manager"
+}
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "══════════════════════════════════════════════" -ForegroundColor Green
+Write-Host "  Setup complete!" -ForegroundColor Green
+Write-Host "══════════════════════════════════════════════" -ForegroundColor Green
+Write-Host ""
+Write-Host "  Manager API   : http://localhost:8090" -ForegroundColor Cyan
+Write-Host "  Manager key   : $apiKey" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "  Update your backend appsettings:" -ForegroundColor Yellow
+Write-Host '  "VPS": {' -ForegroundColor Gray
+Write-Host '    "GatewayUrl": "http://localhost:8090",' -ForegroundColor Gray
+Write-Host "    `"ManagerApiKey`": `"$apiKey`"," -ForegroundColor Gray
+Write-Host '    "PublicIp": "localhost",' -ForegroundColor Gray
+Write-Host '    "Enabled": true' -ForegroundColor Gray
+Write-Host '  }' -ForegroundColor Gray
+Write-Host ""
+Write-Host "  Useful commands:" -ForegroundColor Yellow
+Write-Host "    docker logs -f devpilot-sandbox-manager   # live logs"
+Write-Host "    docker ps --filter name=sandbox-          # running sandboxes"
+Write-Host "    docker compose -f infra\sandbox\windows\docker-compose.yml down"
+Write-Host ""

--- a/src/API/appsettings.json
+++ b/src/API/appsettings.json
@@ -1,0 +1,62 @@
+{
+  "ConnectionStrings": {
+    "Postgres": "Host=localhost;Port=5432;Username=YOUR_USERNAME;Password=YOUR_PASSWORD;Database=YOUR_DATABASE"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "JWT": {
+    "SecretKey": "YOUR_SECRET_KEY_MIN_32_CHARACTERS_LONG",
+    "Issuer": "DevPilot",
+    "Audience": "DevPilot"
+  },
+  "AuthProviders": {
+    "Local": {
+      "Enabled": false
+    },
+    "GitHub": {
+      "Enabled": true,
+      "Type": "BackendOAuth",
+      "ClientId": "YOUR_GITHUB_CLIENT_ID",
+      "ClientSecret": "YOUR_GITHUB_CLIENT_SECRET",
+      "RedirectUri": "http://localhost:4200/auth/callback/GitHub",
+      "Scopes": "repo,read:org"
+    },
+    "AzureAd": {
+      "Enabled": true,
+      "Type": "FrontendOidc",
+      "Authority": "https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0",
+      "ClientId": "YOUR_AZURE_BACKEND_CLIENT_ID",
+      "SpaClientId": "YOUR_AZURE_SPA_CLIENT_ID",
+      "TenantId": "YOUR_TENANT_ID",
+      "Scopes": "openid profile email User.Read",
+      "ProfileEndpoint": "https://graph.microsoft.com/v1.0/me"
+    },
+    "Duende": {
+      "Enabled": false,
+      "Type": "FrontendOidc",
+      "Authority": "https://your-identityserver.com",
+      "ClientId": "YOUR_DUENDE_BACKEND_CLIENT_ID",
+      "SpaClientId": "YOUR_DUENDE_SPA_CLIENT_ID",
+      "Scopes": "openid profile email",
+      "ProfileEndpoint": ""
+    }
+  },
+  "AI": {
+    "Endpoint": "https://api.openai.com/v1",
+    "ApiKey": "YOUR_AI_API_KEY",
+    "Model": "gpt-4",
+    "UseAzureOpenAI": false
+  },
+  "VPS": {
+    "GatewayUrl": "http://localhost:8090",
+    "ManagerApiKey": "YOUR_MANAGER_API_KEY",
+    "PublicIp": "YOUR_VPS_PUBLIC_IP",
+    "SessionTimeoutMinutes": 60,
+    "Enabled": false
+  }
+}


### PR DESCRIPTION
- Sandbox authentication: per-sandbox Bearer token and VNC password
  - manager.py generates sandbox_token and vnc_password on container creation
  - devpilot-bridge.py validates Authorization: Bearer header
  - x11vnc started with per-sandbox password
  - Backend SandboxService/SandboxController proxy auth (X-Api-Key never exposed)
  - Frontend auth interceptor: JWT only added if no Authorization header present
  - VncViewerService and VncViewerComponent pass vncPassword to noVNC iframe URL

- Sandbox lifecycle: GET /api/sandboxes endpoint for page-refresh restore
  - Added ListSandboxesAsync to ISandboxService + SandboxListItem record
  - manager.py list endpoint now includes bridge_port

- Backlog generation fixes
  - Robust JSON extraction: accepts ```json, ```, or raw JSON fallback
  - containsBacklogJson: only requires "epics" (no strict fence requirement)
  - Active sandbox lookup uses implementationContext.repositoryId + storyId instead of fragile title.includes() match

- VNC viewer: hide Push & Create PR for backlog and analysis sandboxes

- Multi-platform sandbox setup
  - infra/sandbox/linux/: setup.sh wrapper + Linux-specific README (systemd, firewall)
  - infra/sandbox/mac/: setup.sh wrapper + macOS-specific README (local dev)
  - infra/sandbox/windows/: full PowerShell setup (no WSL required)
    - setup.ps1 builds desktop image via Docker named pipe
    - docker-compose.yml mounts \\.\pipe\docker_engine
    - manager.py standalone + Dockerfile.manager
  - setup.sh: BUILD_ONLY=1 mode for Windows Docker setup
  - infra/sandbox/README.md: updated with platform table

Made-with: Cursor